### PR TITLE
Better locking mechanism

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/data/AbstractDatabaseTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/AbstractDatabaseTest.java
@@ -136,6 +136,20 @@ public class AbstractDatabaseTest extends DatabaseTestCase {
         assertEquals(0, dao.count(Employee.class, Criterion.all));
     }
 
+    public void testAcquireExclusiveLockFailsWhenInTransaction() {
+        testThrowsException(new Runnable() {
+            @Override
+            public void run() {
+                badDatabase.beginTransaction();
+                try {
+                    badDatabase.acquireExclusiveLock();
+                } finally {
+                    badDatabase.endTransaction();
+                }
+            }
+        }, IllegalStateException.class);
+    }
+
     /**
      * {@link TestDatabase} that intentionally fails in onUpgrade and onDowngrade
      */

--- a/squidb-tests/src/com/yahoo/squidb/sql/AttachDetachTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/AttachDetachTest.java
@@ -68,6 +68,20 @@ public class AttachDetachTest extends DatabaseTestCase {
         assertFalse(database2.tryExecStatement(insert)); // Should fail after detatch
     }
 
+    public void testAttachWhileOtherDbInTransactionThrowsException() {
+        testThrowsException(new Runnable() {
+            @Override
+            public void run() {
+                database.beginTransaction();
+                try {
+                    database2.attachDatabase(database);
+                } finally {
+                    database.endTransaction();
+                }
+            }
+        }, IllegalStateException.class);
+    }
+
     public void testAttachBlocksNewTransactions() {
         try {
             testAttachDetachConcurrency(false);

--- a/squidb/src/com/yahoo/squidb/data/AbstractDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractDatabase.java
@@ -300,8 +300,11 @@ public abstract class AbstractDatabase {
      * a database can only be attached to one other database. This method will throw an exception
      * if the other database is already attached somewhere.
      * <p>
+     * Caveats:
      * Make sure you call {@link #detachDatabase(AbstractDatabase)} when you are done! Otherwise, the other
      * database will not be unlocked.
+     * <p>
+     * If the database being attached is in a transaction that was started on this thread, an exception will be thrown.
      *
      * @return the alias used to attach the database; this can be used to qualify tables using
      * {@link Table#qualifiedFromDatabase(String)}
@@ -333,6 +336,11 @@ public abstract class AbstractDatabase {
         if (attachedTo != null) {
             throw new IllegalArgumentException(
                     "Database " + getName() + " is already attached to " + attachedTo.getName());
+        }
+        if (inTransaction()) {
+            throw new IllegalStateException(
+                    "Cannot attach database " + getName() + " to " + attachTo.getName() + " -- " + getName()
+                            + " is in a transaction on the calling thread");
         }
 
         acquireExclusiveLock();


### PR DESCRIPTION
@sciolizer helpfully pointed out to me that I had re-invented a read/write lock with my locking mechanism for protecting attached databases. This replaces my cruder version of that locking with a ReentrantReadWriteLock, which is much simpler to understand and maintain.

Note: it's important to remember that the lock is not actually protecting database reads and writes (both of those can use the read lock)--it's only for protecting exclusive access to the database connection for things like attaches. For that reason I've left the original method naming of "exclusive" and "non-exclusive" locks and documented how each should be used.