### PR TITLE
Better typesafety for ContentValues constructors

### DIFF
--- a/squidb-processor/src/com/yahoo/squidb/processor/TypeConstants.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/TypeConstants.java
@@ -65,11 +65,17 @@ public class TypeConstants {
     public static final DeclaredTypeName BLOB_PROPERTY = new DeclaredTypeName(PROPERTY.toString(), "BlobProperty");
 
     public static final DeclaredTypeName PROPERTY_ARRAY;
+    public static final DeclaredTypeName PROPERTY_VARARGS;
 
     static {
         PROPERTY.setTypeArgs(Arrays.asList(GenericName.DEFAULT_WILDCARD));
+
         PROPERTY_ARRAY = PROPERTY.clone();
         PROPERTY_ARRAY.setArrayDepth(1);
+
+        PROPERTY_VARARGS = PROPERTY.clone();
+        PROPERTY_VARARGS.setArrayDepth(1);
+        PROPERTY_VARARGS.setIsVarArgs(true);
     }
 
     private static final Set<DeclaredTypeName> PROPERTY_TYPES = new HashSet<DeclaredTypeName>();

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
@@ -344,8 +344,14 @@ public abstract class ModelFileWriter<T extends Annotation> {
 
         params.setArgumentTypes(Arrays.asList(TypeConstants.CONTENT_VALUES)).setArgumentNames("contentValues");
         writer.beginConstructorDeclaration(params)
+                .writeStatement(Expressions.callMethod("this", "contentValues", PROPERTIES_ARRAY_NAME))
+                .finishMethodDefinition();
+
+        params.setArgumentTypes(Arrays.asList(TypeConstants.CONTENT_VALUES, TypeConstants.PROPERTY_VARARGS))
+                .setArgumentNames("contentValues", "withProperties");
+        writer.beginConstructorDeclaration(params)
                 .writeStringStatement("this()")
-                .writeStringStatement("readPropertiesFromContentValues(contentValues)")
+                .writeStringStatement("readPropertiesFromContentValues(contentValues, withProperties)")
                 .finishMethodDefinition();
     }
 

--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.squidb.data;
 
+import android.content.ContentValues;
+
 import com.yahoo.squidb.sql.Criterion;
 import com.yahoo.squidb.sql.Property;
 import com.yahoo.squidb.test.DatabaseTestCase;
@@ -76,5 +78,29 @@ public class ModelTest extends DatabaseTestCase {
                 fail("The PROPERTIES array contained a deprecated property");
             }
         }
+    }
+
+    public void testTypesafeReadFromContentValues() {
+        final ContentValues values = new ContentValues();
+        values.put(TestModel.FIRST_NAME.getName(), "A");
+        values.put(TestModel.LAST_NAME.getName(), "B");
+        values.put(TestModel.BIRTHDAY.getName(), 1); // Putting an int where long expected
+        values.put(TestModel.IS_HAPPY.getName(), 1); // Putting an int where boolean expected
+        values.put(TestModel.SOME_DOUBLE.getName(), 1); // Putting an int where double expected
+
+        TestModel fromValues = new TestModel(values);
+        assertEquals("A", fromValues.getFirstName());
+        assertEquals("B", fromValues.getLastName());
+        assertEquals(1L, fromValues.getBirthday().longValue());
+        assertTrue(fromValues.isHappy());
+        assertEquals(1.0, fromValues.getSomeDouble());
+
+        values.put(TestModel.IS_HAPPY.getName(), "ABC");
+        testThrowsException(new Runnable() {
+            @Override
+            public void run() {
+                new TestModel(values);
+            }
+        }, ClassCastException.class);
     }
 }

--- a/squidb-tests/src/com/yahoo/squidb/test/TestModelSpec.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/TestModelSpec.java
@@ -52,7 +52,9 @@ public class TestModelSpec {
 
     @Deprecated
     long someDeprecatedLong;
-    
+
+    double someDouble;
+
     @ColumnSpec(name = "dollar123abc")
     int $123abc;
 

--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -290,13 +290,8 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
     private <TYPE> TYPE getFromValues(Property<TYPE> property, ContentValues values) {
         Object value = values.get(property.getName());
 
-        // resolve properties that were retrieved with a different type than accessed
-        try {
-            // Will throw a ClassCastException if the value could not be coerced
-            return (TYPE) property.accept(valueCastingVisitor, value);
-        } catch (NumberFormatException e) {
-            return (TYPE) getDefaultValues().get(property.getExpression());
-        }
+        // Will throw a ClassCastException if the value could not be coerced to the correct type
+        return (TYPE) property.accept(valueCastingVisitor, value);
     }
 
     /**
@@ -578,7 +573,11 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
             } else if (data instanceof Boolean) {
                 return (Boolean) data ? 1 : 0;
             } else if (data instanceof String) {
-                return Integer.valueOf((String) data);
+                try {
+                    return Integer.valueOf((String) data);
+                } catch (NumberFormatException e) {
+                    // Suppress and throw the class cast
+                }
             }
             throw new ClassCastException("Value " + data + " could not be cast to Integer");
         }
@@ -592,7 +591,11 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
             } else if (data instanceof Boolean) {
                 return (Boolean) data ? 1L : 0L;
             } else if (data instanceof String) {
-                return Long.valueOf((String) data);
+                try {
+                    return Long.valueOf((String) data);
+                } catch (NumberFormatException e) {
+                    // Suppress and throw the class cast
+                }
             }
             throw new ClassCastException("Value " + data + " could not be cast to Long");
         }
@@ -604,7 +607,11 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
             } else if (data instanceof Number) {
                 return ((Number) data).doubleValue();
             } else if (data instanceof String) {
-                return (Double.valueOf((String) data));
+                try {
+                    return Double.valueOf((String) data);
+                } catch (NumberFormatException e) {
+                    // Suppress and throw the class cast
+                }
             }
             throw new ClassCastException("Value " + data + " could not be cast to Double");
         }

--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -580,7 +580,7 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
             } else if (data instanceof String) {
                 return Integer.valueOf((String) data);
             }
-            return data;
+            throw new ClassCastException("Value " + data + " could not be cast to Integer");
         }
 
         @Override
@@ -594,7 +594,7 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
             } else if (data instanceof String) {
                 return Long.valueOf((String) data);
             }
-            return data;
+            throw new ClassCastException("Value " + data + " could not be cast to Long");
         }
 
         @Override
@@ -606,7 +606,7 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
             } else if (data instanceof String) {
                 return (Double.valueOf((String) data));
             }
-            return data;
+            throw new ClassCastException("Value " + data + " could not be cast to Double");
         }
 
         @Override
@@ -625,11 +625,14 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
             } else if (data instanceof Number) {
                 return ((Number) data).intValue() != 0;
             }
-            return data;
+            throw new ClassCastException("Value " + data + " could not be cast to Boolean");
         }
 
         @Override
         public Object visitBlob(Property<byte[]> property, Object data) {
+            if (data != null && !(data instanceof byte[])) {
+                throw new ClassCastException("Data " + data + " could not be cast to byte[]");
+            }
             return data;
         }
 


### PR DESCRIPTION
Our type safety when constructing models from ContentValues was lacking. This PR improves the situation:

There are now two constructors generated in each model class for constructing from ContentValues. One takes the values and a list of properties to read from the values, which is used to type-safely read each value from the ContentValues--if anything is of the wrong type or can't be coerced, a ClassCastException will be thrown. The other constructor just takes a single ContentValues and calls the two-arg constructor with the PROPERTIES array for that model.

This PR also increases type safety by making ValueCastingVisitor explicitly throw a ClassCastException when type coercion fails. We used to rely on the cast to (TYPE) in the get() method to throw this, but that won't work when get() is called with a property of unknown type (e.g. Property<?>).