### PR TITLE
Fix defaultValues bug

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -103,4 +103,22 @@ public class ModelTest extends DatabaseTestCase {
             }
         }, ClassCastException.class);
     }
+
+    public void testValueCoercionAppliesToAllValues() {
+        // Make sure the model is initialized with values and setValues
+        ContentValues values = new ContentValues();
+        values.put(TestModel.FIRST_NAME.getName(), "A");
+        TestModel model = new TestModel();
+        model.readPropertiesFromContentValues(values, TestModel.FIRST_NAME);
+        model.setFirstName("B");
+
+        model.getDefaultValues().put(TestModel.IS_HAPPY.getName(), 1);
+        assertTrue(model.isHappy()); // Test default values
+        model.getDatabaseValues().put(TestModel.IS_HAPPY.getName(), 0);
+        assertFalse(model.isHappy()); // Test database values
+        model.getSetValues().put(TestModel.IS_HAPPY.getName(), 1);
+        assertTrue(model.isHappy()); // Test set values
+
+        model.getDefaultValues().put(TestModel.IS_HAPPY.getName(), true); // Reset the static variable
+    }
 }

--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -208,7 +208,8 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
         if (values != null) {
             for (Property<?> property : properties) {
                 if (values.containsKey(property.getName())) {
-                    SquidUtilities.putInto(this.values, property.getName(), getFromValues(property, values), true);
+                    SquidUtilities.putInto(this.values, property.getName(),
+                            getFromValues(property, values, false), true);
                 }
             }
         }
@@ -273,11 +274,11 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
     @SuppressWarnings("unchecked")
     public <TYPE> TYPE get(Property<TYPE> property) {
         if (setValues != null && setValues.containsKey(property.getName())) {
-            return getFromValues(property, setValues);
+            return getFromValues(property, setValues, false);
         } else if (values != null && values.containsKey(property.getName())) {
-            return getFromValues(property, values);
+            return getFromValues(property, values, false);
         } else if (getDefaultValues().containsKey(property.getExpression())) {
-            return (TYPE) getDefaultValues().get(property.getExpression());
+            return getFromValues(property, getDefaultValues(), true);
         } else {
             throw new UnsupportedOperationException(property.getName()
                     + " not found in model. Make sure the value was set explicitly, read from a cursor,"
@@ -287,8 +288,8 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
     }
 
     @SuppressWarnings("unchecked")
-    private <TYPE> TYPE getFromValues(Property<TYPE> property, ContentValues values) {
-        Object value = values.get(property.getName());
+    private <TYPE> TYPE getFromValues(Property<TYPE> property, ContentValues values, boolean useExpression) {
+        Object value = values.get(useExpression ? property.getExpression() : property.getName());
 
         // Will throw a ClassCastException if the value could not be coerced to the correct type
         return (TYPE) property.accept(valueCastingVisitor, value);


### PR DESCRIPTION
Fix a bug where default values wouldn't get the ValueCastingVisitor, which could cause problems for boolean properties with integer defaults. This fixes a regression introduced in #14.

Long term we should really move to something better/more typesafe for our defaults, like separate annotations for them.