### PR TITLE
Fix validation race condition

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/sql/QueryTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/QueryTest.java
@@ -892,7 +892,7 @@ public class QueryTest extends DatabaseTestCase {
         }
     }
 
-    public void testParenthesizeWherePropagates() {
+    public void testValidationPropagatesToSubqueryJoinAndCompoundSelect() {
         Query subquery = Query.select(Thing.FOO).from(Thing.TABLE).where(Thing.BAR.gt(0));
         Query joinSubquery = Query.select(Thing.BAR).from(Thing.TABLE).where(Thing.FOO.isNotEmpty());
         Query compoundSubquery = Query.select(Thing.BAZ).from(Thing.TABLE).where(Thing.IS_ALIVE.isTrue());
@@ -902,16 +902,10 @@ public class QueryTest extends DatabaseTestCase {
         Query query = Query.select().from(subqueryTable).innerJoin(joinTable, Criterion.all)
                 .union(compoundSubquery);
 
-        final int subqueryLength = subquery.toRawSql().length();
-        final int joinSubqueryLength = joinSubquery.toRawSql().length();
-        final int compoundSubqueryLength = compoundSubquery.toRawSql().length();
-        final int queryLength = query.toRawSql().length();
+        final int queryLength = query.compile().sql.length();
 
-        query.parenthesizeWhere(true);
-        assertEquals(subqueryLength + 2, subquery.toRawSql().length());
-        assertEquals(joinSubqueryLength + 2, joinSubquery.toRawSql().length());
-        assertEquals(compoundSubqueryLength + 2, compoundSubquery.toRawSql().length());
-        assertEquals(queryLength + 6, query.toRawSql().length());
+        CompiledStatement withValidation = query.compileWithValidation();
+        assertEquals(queryLength + 6, withValidation.sql.length());
     }
 
     public void testNeedsValidationUpdatedByMutation() {

--- a/squidb-tests/src/com/yahoo/squidb/sql/QueryTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/QueryTest.java
@@ -904,8 +904,8 @@ public class QueryTest extends DatabaseTestCase {
 
         final int queryLength = query.compile().sql.length();
 
-        CompiledStatement withValidation = query.compileWithValidation();
-        assertEquals(queryLength + 6, withValidation.sql.length());
+        String withValidation = query.sqlForValidation();
+        assertEquals(queryLength + 6, withValidation.length());
     }
 
     public void testNeedsValidationUpdatedByMutation() {

--- a/squidb/src/com/yahoo/squidb/data/DatabaseDao.java
+++ b/squidb/src/com/yahoo/squidb/data/DatabaseDao.java
@@ -83,8 +83,8 @@ public class DatabaseDao {
             query = query.from(table); // If argument was frozen, we may get a new object
         }
         if (query.needsValidation()) {
-            CompiledStatement compiled = query.compileWithValidation();
-            database.compileStatement(compiled.sql); // throws if the statement fails to compile
+            String compiled = query.sqlForValidation();
+            database.compileStatement(compiled); // throws if the statement fails to compile
         }
         CompiledStatement compiled = query.compile();
         Cursor cursor = database.rawQuery(compiled.sql, compiled.sqlArgs);

--- a/squidb/src/com/yahoo/squidb/data/DatabaseDao.java
+++ b/squidb/src/com/yahoo/squidb/data/DatabaseDao.java
@@ -83,10 +83,8 @@ public class DatabaseDao {
             query = query.from(table); // If argument was frozen, we may get a new object
         }
         if (query.needsValidation()) {
-            query.parenthesizeWhere(true);
-            CompiledStatement compiled = query.compile();
+            CompiledStatement compiled = query.compileWithValidation();
             database.compileStatement(compiled.sql); // throws if the statement fails to compile
-            query.parenthesizeWhere(false);
         }
         CompiledStatement compiled = query.compile();
         Cursor cursor = database.rawQuery(compiled.sql, compiled.sqlArgs);

--- a/squidb/src/com/yahoo/squidb/sql/CompoundSelect.java
+++ b/squidb/src/com/yahoo/squidb/sql/CompoundSelect.java
@@ -73,7 +73,7 @@ public final class CompoundSelect extends Validatable {
     }
 
     @Override
-    public void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder,
+    void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder,
             boolean withValidation) {
         sql.append(operator.toString()).append(" ");
         query.appendCompiledStringWithArguments(sql, selectionArgsBuilder, withValidation);

--- a/squidb/src/com/yahoo/squidb/sql/CompoundSelect.java
+++ b/squidb/src/com/yahoo/squidb/sql/CompoundSelect.java
@@ -12,9 +12,9 @@ import java.util.List;
  *
  * @see <a href="http://www.sqlite.org/lang_select.html#compound">http://www.sqlite.org/lang_select.html#compound</a>
  */
-public final class CompoundSelect extends CompilableWithArguments {
+public final class CompoundSelect extends Validatable {
 
-    private static enum CompoundSelectOperator {
+    private enum CompoundSelectOperator {
         UNION("UNION"),
         UNION_ALL("UNION ALL"),
         INTERSECT("INTERSECT"),
@@ -22,7 +22,7 @@ public final class CompoundSelect extends CompilableWithArguments {
 
         private final String expression;
 
-        private CompoundSelectOperator(String expression) {
+        CompoundSelectOperator(String expression) {
             this.expression = expression;
         }
 
@@ -73,9 +73,9 @@ public final class CompoundSelect extends CompilableWithArguments {
     }
 
     @Override
-    void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder) {
+    public void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder,
+            boolean withValidation) {
         sql.append(operator.toString()).append(" ");
-        query.appendCompiledStringWithArguments(sql, selectionArgsBuilder);
+        query.appendCompiledStringWithArguments(sql, selectionArgsBuilder, withValidation);
     }
-
 }

--- a/squidb/src/com/yahoo/squidb/sql/Join.java
+++ b/squidb/src/com/yahoo/squidb/sql/Join.java
@@ -15,9 +15,9 @@ import java.util.List;
  * datasets. If a join constraint is specified, it is evaluated for each row of the cartesian product as a boolean
  * expression, and only rows for which the expression evaluates to true are included in the result.
  */
-public class Join extends CompilableWithArguments {
+public class Join extends Validatable {
 
-    private static enum JoinType {
+    private enum JoinType {
         INNER, LEFT, CROSS
     }
 
@@ -109,9 +109,15 @@ public class Join extends CompilableWithArguments {
     }
 
     @Override
-    void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder) {
+    void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder,
+            boolean withValidation) {
         sql.append(joinType).append(" JOIN ");
-        joinTable.appendCompiledStringWithArguments(sql, selectionArgsBuilder);
+        if (joinTable instanceof SubqueryTable) {
+            ((SubqueryTable) joinTable)
+                    .appendCompiledStringWithArguments(sql, selectionArgsBuilder, withValidation);
+        } else {
+            joinTable.appendCompiledStringWithArguments(sql, selectionArgsBuilder);
+        }
         sql.append(" ");
         if (criterions != null) {
             sql.append("ON ");

--- a/squidb/src/com/yahoo/squidb/sql/Query.java
+++ b/squidb/src/com/yahoo/squidb/sql/Query.java
@@ -35,7 +35,6 @@ public final class Query extends TableStatement {
     private boolean immutable = false;
 
     private boolean needsValidation = false;
-    private boolean parenthesizeWhere = false;
 
     private ArrayList<Field<?>> selectAllCache = null;
 
@@ -451,35 +450,6 @@ public final class Query extends TableStatement {
     }
 
     /**
-     * Set whether to use additional parentheses surrounding the WHERE clause of this query. This setting is propagated
-     * to subqueries in the FROM and JOIN clauses as well as any compound select clauses.
-     *
-     * @param parenthesize true to surround the WHERE clause with parentheses, false otherwise
-     */
-    public void parenthesizeWhere(boolean parenthesize) {
-        if (this.parenthesizeWhere != parenthesize) {
-            this.parenthesizeWhere = parenthesize;
-            invalidateCompileCache();
-        }
-
-        if (table instanceof SubqueryTable) {
-            ((SubqueryTable) table).query.parenthesizeWhere(parenthesize);
-        }
-        if (joins != null) {
-            for (Join join : joins) {
-                if (join.joinTable instanceof SubqueryTable) {
-                    ((SubqueryTable) join.joinTable).query.parenthesizeWhere(parenthesize);
-                }
-            }
-        }
-        if (compoundSelects != null) {
-            for (CompoundSelect compoundSelect : compoundSelects) {
-                compoundSelect.query.parenthesizeWhere(parenthesize);
-            }
-        }
-    }
-
-    /**
      * Mark that this query should be checked for syntactic anomalies in the WHERE clause (e.g. if a raw selection was
      * applied)
      */
@@ -512,14 +482,26 @@ public final class Query extends TableStatement {
         return toString().hashCode();
     }
 
+    public final CompiledStatement compileWithValidation() {
+        List<Object> argsOrReferences = new ArrayList<Object>();
+        StringBuilder sql = new StringBuilder(STRING_BUILDER_INITIAL_CAPACITY);
+        appendCompiledStringWithArguments(sql, argsOrReferences, true);
+        return new CompiledArgumentResolver(sql.toString(), argsOrReferences).resolveToCompiledStatement();
+    }
+
     @Override
     protected void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder) {
+        appendCompiledStringWithArguments(sql, selectionArgsBuilder, false);
+    }
+
+    protected void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder,
+            boolean withValidation) {
         visitSelectClause(sql, selectionArgsBuilder);
-        visitFromClause(sql, selectionArgsBuilder);
-        visitJoinClause(sql, selectionArgsBuilder);
-        visitWhereClause(sql, selectionArgsBuilder);
+        visitFromClause(sql, selectionArgsBuilder, withValidation);
+        visitJoinClause(sql, selectionArgsBuilder, withValidation);
+        visitWhereClause(sql, selectionArgsBuilder, withValidation);
         visitGroupByClause(sql, selectionArgsBuilder);
-        visitCompoundSelectClauses(sql, selectionArgsBuilder);
+        visitCompoundSelectClauses(sql, selectionArgsBuilder, withValidation);
         visitOrderByClause(sql, selectionArgsBuilder);
         visitLimitClause(sql);
     }
@@ -537,32 +519,37 @@ public final class Query extends TableStatement {
         SqlUtils.appendConcatenatedCompilables(fields, sql, selectionArgsBuilder, ", ");
     }
 
-    private void visitFromClause(StringBuilder sql, List<Object> selectionArgsBuilder) {
+    private void visitFromClause(StringBuilder sql, List<Object> selectionArgsBuilder, boolean withValidation) {
         if (table == null) {
             return;
         }
         sql.append(" FROM ");
-        table.appendCompiledStringWithArguments(sql, selectionArgsBuilder);
+        if (table instanceof SubqueryTable) {
+            ((SubqueryTable) table)
+                    .appendCompiledStringWithArguments(sql, selectionArgsBuilder, withValidation);
+        } else {
+            table.appendCompiledStringWithArguments(sql, selectionArgsBuilder);
+        }
     }
 
-    private void visitJoinClause(StringBuilder sql, List<Object> selectionArgsBuilder) {
+    private void visitJoinClause(StringBuilder sql, List<Object> selectionArgsBuilder, boolean withValidation) {
         if (isEmpty(joins)) {
             return;
         }
         sql.append(" ");
-        SqlUtils.appendConcatenatedCompilables(joins, sql, selectionArgsBuilder, " ");
+        SqlUtils.appendConcatenatedValidatables(joins, sql, selectionArgsBuilder, " ", withValidation);
     }
 
-    private void visitWhereClause(StringBuilder sql, List<Object> selectionArgsBuilder) {
+    private void visitWhereClause(StringBuilder sql, List<Object> selectionArgsBuilder, boolean withValidation) {
         if (isEmpty(criterions)) {
             return;
         }
         sql.append(" WHERE ");
-        if (parenthesizeWhere) {
+        if (withValidation) {
             sql.append("(");
         }
         SqlUtils.appendConcatenatedCompilables(criterions, sql, selectionArgsBuilder, " AND ");
-        if (parenthesizeWhere) {
+        if (withValidation) {
             sql.append(")");
         }
     }
@@ -585,12 +572,13 @@ public final class Query extends TableStatement {
         SqlUtils.appendConcatenatedCompilables(havings, sql, selectionArgsBuilder, " AND ");
     }
 
-    private void visitCompoundSelectClauses(StringBuilder sql, List<Object> selectionArgsBuilder) {
+    private void visitCompoundSelectClauses(StringBuilder sql, List<Object> selectionArgsBuilder,
+            boolean withValidation) {
         if (isEmpty(compoundSelects)) {
             return;
         }
         sql.append(" ");
-        SqlUtils.appendConcatenatedCompilables(compoundSelects, sql, selectionArgsBuilder, " ");
+        SqlUtils.appendConcatenatedValidatables(compoundSelects, sql, selectionArgsBuilder, " ", withValidation);
     }
 
     private void visitOrderByClause(StringBuilder sql, List<Object> selectionArgsBuilder) {
@@ -663,7 +651,6 @@ public final class Query extends TableStatement {
         newQuery.offset = offset;
         newQuery.distinct = distinct;
         newQuery.needsValidation = needsValidation;
-        newQuery.parenthesizeWhere = parenthesizeWhere;
         return newQuery;
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/Query.java
+++ b/squidb/src/com/yahoo/squidb/sql/Query.java
@@ -482,11 +482,11 @@ public final class Query extends TableStatement {
         return toString().hashCode();
     }
 
-    public final CompiledStatement compileWithValidation() {
+    public final String sqlForValidation() {
         List<Object> argsOrReferences = new ArrayList<Object>();
         StringBuilder sql = new StringBuilder(STRING_BUILDER_INITIAL_CAPACITY);
         appendCompiledStringWithArguments(sql, argsOrReferences, true);
-        return new CompiledArgumentResolver(sql.toString(), argsOrReferences).resolveToCompiledStatement();
+        return new CompiledArgumentResolver(sql.toString(), argsOrReferences).resolveToCompiledStatement().sql;
     }
 
     @Override

--- a/squidb/src/com/yahoo/squidb/sql/SqlUtils.java
+++ b/squidb/src/com/yahoo/squidb/sql/SqlUtils.java
@@ -132,6 +132,20 @@ public class SqlUtils {
         }
     }
 
+    static void appendConcatenatedValidatables(List<? extends Validatable> validatables, StringBuilder sql,
+            List<Object> selectionArgsBuilder, String separator, boolean withValidation) {
+        if (validatables != null && !validatables.isEmpty()) {
+            boolean needSeparator = false;
+            for (Validatable compilable : validatables) {
+                if (needSeparator) {
+                    sql.append(separator);
+                }
+                needSeparator = true;
+                compilable.appendCompiledStringWithArguments(sql, selectionArgsBuilder, withValidation);
+            }
+        }
+    }
+
     /**
      * Escape a pattern for use in LIKE clauses. LIKE clauses support the meta-characters '_' (matching a single
      * character) and '%' (matching a string of any length, including the empty string). Use this method to escape

--- a/squidb/src/com/yahoo/squidb/sql/SubqueryTable.java
+++ b/squidb/src/com/yahoo/squidb/sql/SubqueryTable.java
@@ -45,8 +45,13 @@ public class SubqueryTable extends QueryTable {
 
     @Override
     void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder) {
+        appendCompiledStringWithArguments(sql, selectionArgsBuilder, false);
+    }
+
+    void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder,
+            boolean withValidation) {
         sql.append("(");
-        query.appendCompiledStringWithArguments(sql, selectionArgsBuilder);
+        query.appendCompiledStringWithArguments(sql, selectionArgsBuilder, withValidation);
         sql.append(") AS ").append(getName());
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/TableStatement.java
+++ b/squidb/src/com/yahoo/squidb/sql/TableStatement.java
@@ -20,7 +20,7 @@ public abstract class TableStatement extends CompilableWithArguments implements 
      *
      * @see <a href="http://www.sqlite.org/lang_conflict.html">http://www.sqlite.org/lang_conflict.html</a>
      */
-    public static enum ConflictAlgorithm {
+    public enum ConflictAlgorithm {
         /**
          * No conflict algorithm specified.
          */
@@ -53,7 +53,7 @@ public abstract class TableStatement extends CompilableWithArguments implements 
 
         private final int androidValue;
 
-        private ConflictAlgorithm(int androidValue) {
+        ConflictAlgorithm(int androidValue) {
             this.androidValue = androidValue;
         }
 

--- a/squidb/src/com/yahoo/squidb/sql/Validatable.java
+++ b/squidb/src/com/yahoo/squidb/sql/Validatable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.sql;
+
+import java.util.List;
+
+/**
+ * An extension of compilable that lets us pass a boolean flag to signal that extra validation is needed. This
+ * is useful when compiling queries that need validation to guard against malicious arguments.
+ */
+abstract class Validatable extends CompilableWithArguments {
+
+    @Override
+    final void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder) {
+        appendCompiledStringWithArguments(sql, selectionArgsBuilder, false);
+    }
+
+    abstract void appendCompiledStringWithArguments(StringBuilder sql, List<Object> selectionArgsBuilder,
+            boolean withValidation);
+}


### PR DESCRIPTION
The 'parenthesizeWhere' approach we took when checking queries that needed validation had a race condition that could cause SQL syntax errors. Specifically, this could arise if there was a subquery shared by many other queries--e.g., exactly what happens when using ContentProviderQueryBuilder with a subquery ViewModel. If queries were being executed on multiple threads, validation on thread A could parenthesize the where clause of the shared subquery while thread B did the same. Thread A could then unset the parenthesize where flag before thread B was done compiling the query, resulting in unbalanced parentheses for thread B. 

Note: while this problem could theoretically apply to any Query that has requestValidation called on it, the only place where SquiDB uses it is in ContentProviderQueryBuilder, so it's very unlikely that users not using CPQB would encounter this problem.

This PR fixes the issue by removing the statefulness of the parenthesizeWhere flag and just passing a boolean argument through to the relevant methods when compiling Query objects into SQL. This should allow multiple threads to validate queries that have shared state without interfering with each other.

I'm pretty sure that this should fix the problem and is the correct approach, but I don't have any great ideas for new unit tests to confirm at the moment. Let's hold off on merging this PR until I can add at least one or two new ones to ensure things are definitely working as expected.

UPDATE: added a unit test based on a suggestion by @jdkoren. The new test fails on master by forcing the race condition, but passes on this PR.