### PR TITLE
More ContentValues typesafety

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -87,6 +87,7 @@ public class ModelTest extends DatabaseTestCase {
         values.put(TestModel.BIRTHDAY.getName(), 1); // Putting an int where long expected
         values.put(TestModel.IS_HAPPY.getName(), 1); // Putting an int where boolean expected
         values.put(TestModel.SOME_DOUBLE.getName(), 1); // Putting an int where double expected
+        values.put(TestModel.$_123_ABC.getName(), "1"); // Putting a String where int expected
 
         TestModel fromValues = new TestModel(values);
         assertEquals("A", fromValues.getFirstName());
@@ -94,12 +95,40 @@ public class ModelTest extends DatabaseTestCase {
         assertEquals(1L, fromValues.getBirthday().longValue());
         assertTrue(fromValues.isHappy());
         assertEquals(1.0, fromValues.getSomeDouble());
+        assertEquals(1, fromValues.get$123abc().intValue());
 
         values.put(TestModel.IS_HAPPY.getName(), "ABC");
         testThrowsException(new Runnable() {
             @Override
             public void run() {
                 new TestModel(values);
+            }
+        }, ClassCastException.class);
+    }
+
+    public void testTypesafeSetFromContentValues() {
+        final ContentValues values = new ContentValues();
+        values.put(TestModel.FIRST_NAME.getName(), "A");
+        values.put(TestModel.LAST_NAME.getName(), "B");
+        values.put(TestModel.BIRTHDAY.getName(), 1); // Putting an int where long expected
+        values.put(TestModel.IS_HAPPY.getName(), 1); // Putting an int where boolean expected
+        values.put(TestModel.SOME_DOUBLE.getName(), 1); // Putting an int where double expected
+        values.put(TestModel.$_123_ABC.getName(), "1"); // Putting a String where int expected
+
+        TestModel fromValues = new TestModel();
+        fromValues.setPropertiesFromContentValues(values, TestModel.PROPERTIES);
+        assertEquals("A", fromValues.getFirstName());
+        assertEquals("B", fromValues.getLastName());
+        assertEquals(1L, fromValues.getBirthday().longValue());
+        assertTrue(fromValues.isHappy());
+        assertEquals(1.0, fromValues.getSomeDouble());
+        assertEquals(1, fromValues.get$123abc().intValue());
+
+        values.put(TestModel.IS_HAPPY.getName(), "ABC");
+        testThrowsException(new Runnable() {
+            @Override
+            public void run() {
+                new TestModel().setPropertiesFromContentValues(values, TestModel.IS_HAPPY);
             }
         }, ClassCastException.class);
     }

--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -390,11 +390,10 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
      * model as set values, i.e. marks the model as dirty with these values.
      */
     public void setPropertiesFromContentValues(ContentValues values, Property<?>... properties) {
-        if (setValues == null) {
-            setValues = new ContentValues();
-        }
-
         if (values != null) {
+            if (setValues == null) {
+                setValues = new ContentValues();
+            }
             for (Property<?> property : properties) {
                 String key = property.getName();
                 if (values.containsKey(key)) {


### PR DESCRIPTION
A few weeks ago we merged #14 to improve the type safety when reading ContentValues into a model object. I discovered that we had another method that was similar--AbstractModel.setValues(). It put values from a ContentValues into the setValues non-typesafely. This PR introduces setPropertiesFromContentValues as an analogue to readPropertiesFromContentValues and removes the bad setValues method.