### PR TITLE
Primary key enhancements

### DIFF
--- a/squidb-annotations/src/com/yahoo/squidb/annotations/PrimaryKey.java
+++ b/squidb-annotations/src/com/yahoo/squidb/annotations/PrimaryKey.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Used to specify that a field in a model spec should be used as the primary key for the table. This annotation
+ * is only relevant for table models, i.e. models using {@link TableModelSpec}. At this time, only a single primary
+ * key of type long is supported. You can use this annotation in combination with {@link ColumnSpec} to customize
+ * your primary key column, including giving it a custom column name or specifying whether or not the column
+ * should autoincrement (using {@link ColumnSpec#constraints()}.
+ * <p/>
+ * If a PrimaryKey annotation is not present in a TableModelSpec class, a default ID property for the table will
+ * automatically be generated.
+ */
+@Target(ElementType.FIELD)
+public @interface PrimaryKey {
+
+}

--- a/squidb-annotations/src/com/yahoo/squidb/annotations/PrimaryKey.java
+++ b/squidb-annotations/src/com/yahoo/squidb/annotations/PrimaryKey.java
@@ -21,4 +21,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface PrimaryKey {
 
+    /**
+     * @return true if AUTOINCREMENT behavior for the primary key should be used. Defaults to true
+     */
+    boolean autoincrement() default true;
+
 }

--- a/squidb-annotations/src/com/yahoo/squidb/annotations/PrimaryKey.java
+++ b/squidb-annotations/src/com/yahoo/squidb/annotations/PrimaryKey.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
  * key of type long is supported. You can use this annotation in combination with {@link ColumnSpec} to customize
  * your primary key column, including giving it a custom column name or specifying whether or not the column
  * should autoincrement (using {@link ColumnSpec#constraints()}.
- * <p/>
+ * <p>
  * If a PrimaryKey annotation is not present in a TableModelSpec class, a default ID property for the table will
  * automatically be generated.
  */

--- a/squidb-jackson-plugin/src/com/yahoo/squidb/jackson/SquidbJacksonSupport.java
+++ b/squidb-jackson-plugin/src/com/yahoo/squidb/jackson/SquidbJacksonSupport.java
@@ -48,7 +48,7 @@ public class SquidbJacksonSupport {
      * Sets the given Jackson-serialized property to the given value
      *
      * @return true if the value object was successfully serialized, false otherwise
-     * @see {@link #getObjectValue}
+     * @see #getObjectValue(AbstractModel, StringProperty, JavaType)
      */
     public static boolean setObjectProperty(AbstractModel model, StringProperty property, Object data) {
         try {

--- a/squidb-processor/src/com/yahoo/squidb/processor/properties/factory/TablePropertyGeneratorFactory.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/properties/factory/TablePropertyGeneratorFactory.java
@@ -47,7 +47,7 @@ public class TablePropertyGeneratorFactory extends PluggablePropertyGeneratorFac
         Class<? extends PropertyGenerator> generatorClass = generatorMap.get(elementType);
         try {
             if (element.getAnnotation(PrimaryKey.class) != null &&
-                    BasicLongPropertyGenerator.handledColumnTypes().contains(elementType)) {
+                    BasicLongPropertyGenerator.class.equals(generatorClass)) {
                 return new BasicIdPropertyGenerator(element, elementType, utils);
             }
             return generatorClass.getConstructor(VariableElement.class, DeclaredTypeName.class, AptUtils.class)

--- a/squidb-processor/src/com/yahoo/squidb/processor/properties/factory/TablePropertyGeneratorFactory.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/properties/factory/TablePropertyGeneratorFactory.java
@@ -7,10 +7,12 @@ package com.yahoo.squidb.processor.properties.factory;
 
 import com.yahoo.aptutils.model.DeclaredTypeName;
 import com.yahoo.aptutils.utils.AptUtils;
+import com.yahoo.squidb.annotations.PrimaryKey;
 import com.yahoo.squidb.annotations.TableModelSpec;
 import com.yahoo.squidb.processor.properties.generators.BasicBlobPropertyGenerator;
 import com.yahoo.squidb.processor.properties.generators.BasicBooleanPropertyGenerator;
 import com.yahoo.squidb.processor.properties.generators.BasicDoublePropertyGenerator;
+import com.yahoo.squidb.processor.properties.generators.BasicIdPropertyGenerator;
 import com.yahoo.squidb.processor.properties.generators.BasicIntegerPropertyGenerator;
 import com.yahoo.squidb.processor.properties.generators.BasicLongPropertyGenerator;
 import com.yahoo.squidb.processor.properties.generators.BasicStringPropertyGenerator;
@@ -44,6 +46,10 @@ public class TablePropertyGeneratorFactory extends PluggablePropertyGeneratorFac
             DeclaredTypeName modelClass) {
         Class<? extends PropertyGenerator> generatorClass = generatorMap.get(elementType);
         try {
+            if (element.getAnnotation(PrimaryKey.class) != null &&
+                    BasicLongPropertyGenerator.handledColumnTypes().contains(elementType)) {
+                return new BasicIdPropertyGenerator(element, elementType, utils);
+            }
             return generatorClass.getConstructor(VariableElement.class, DeclaredTypeName.class, AptUtils.class)
                     .newInstance(element, modelClass, utils);
         } catch (Exception e) {

--- a/squidb-processor/src/com/yahoo/squidb/processor/properties/generators/BasicIdPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/properties/generators/BasicIdPropertyGenerator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.processor.properties.generators;
+
+import com.yahoo.aptutils.model.DeclaredTypeName;
+import com.yahoo.aptutils.utils.AptUtils;
+
+import javax.lang.model.element.VariableElement;
+
+public class BasicIdPropertyGenerator extends BasicLongPropertyGenerator {
+
+    public BasicIdPropertyGenerator(VariableElement element, DeclaredTypeName modelName, AptUtils utils) {
+        super(element, modelName, utils);
+    }
+
+    @Override
+    protected String getColumnDefinition() {
+        String columnDef = super.getColumnDefinition();
+        if (AptUtils.isEmpty(columnDef) || !columnDef.contains("PRIMARY KEY")) {
+            String newColumnDef = "INTEGER PRIMARY KEY AUTOINCREMENT";
+            if (!AptUtils.isEmpty(columnDef)) {
+                newColumnDef += ", " + columnDef;
+            }
+            columnDef = newColumnDef;
+        }
+        return columnDef;
+    }
+}

--- a/squidb-processor/src/com/yahoo/squidb/processor/properties/generators/BasicIdPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/properties/generators/BasicIdPropertyGenerator.java
@@ -7,25 +7,33 @@ package com.yahoo.squidb.processor.properties.generators;
 
 import com.yahoo.aptutils.model.DeclaredTypeName;
 import com.yahoo.aptutils.utils.AptUtils;
+import com.yahoo.squidb.annotations.PrimaryKey;
 
 import javax.lang.model.element.VariableElement;
 
 public class BasicIdPropertyGenerator extends BasicLongPropertyGenerator {
 
+    private final PrimaryKey annotation;
+
     public BasicIdPropertyGenerator(VariableElement element, DeclaredTypeName modelName, AptUtils utils) {
         super(element, modelName, utils);
+        annotation = element.getAnnotation(PrimaryKey.class);
     }
 
     @Override
     protected String getColumnDefinition() {
-        String columnDef = super.getColumnDefinition();
-        if (AptUtils.isEmpty(columnDef) || !columnDef.contains("PRIMARY KEY")) {
-            String newColumnDef = "PRIMARY KEY AUTOINCREMENT";
-            if (!AptUtils.isEmpty(columnDef)) {
-                newColumnDef += ", " + columnDef;
-            }
-            columnDef = newColumnDef;
+        String newColumnDef = "PRIMARY KEY";
+        if (annotation.autoincrement()) {
+            newColumnDef += " AUTOINCREMENT";
         }
-        return columnDef;
+
+        String columnDef = super.getColumnDefinition();
+        if (AptUtils.isEmpty(columnDef)) {
+            return "\"" + newColumnDef + "\"";
+        } else if (columnDef.toUpperCase().contains("PRIMARY KEY")) {
+            return columnDef;
+        } else {
+            return columnDef.replaceFirst("\"", "\"" + newColumnDef + ", ");
+        }
     }
 }

--- a/squidb-processor/src/com/yahoo/squidb/processor/properties/generators/BasicIdPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/properties/generators/BasicIdPropertyGenerator.java
@@ -20,7 +20,7 @@ public class BasicIdPropertyGenerator extends BasicLongPropertyGenerator {
     protected String getColumnDefinition() {
         String columnDef = super.getColumnDefinition();
         if (AptUtils.isEmpty(columnDef) || !columnDef.contains("PRIMARY KEY")) {
-            String newColumnDef = "INTEGER PRIMARY KEY AUTOINCREMENT";
+            String newColumnDef = "PRIMARY KEY AUTOINCREMENT";
             if (!AptUtils.isEmpty(columnDef)) {
                 newColumnDef += ", " + columnDef;
             }

--- a/squidb-processor/src/com/yahoo/squidb/processor/properties/generators/BasicPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/properties/generators/BasicPropertyGenerator.java
@@ -103,7 +103,7 @@ public abstract class BasicPropertyGenerator extends PropertyGenerator {
             if (ColumnSpec.DEFAULT_NONE.equals(toReturn)) {
                 toReturn = "DEFAULT " + columnDefaultValue;
             } else if (!ColumnSpec.DEFAULT_NONE.equals(columnDefaultValue)) {
-                if (!toReturn.contains("DEFAULT")) {
+                if (!toReturn.toUpperCase().contains("DEFAULT")) {
                     toReturn += " DEFAULT " + columnDefaultValue;
                 } else {
                     utils.getMessager().printMessage(Kind.WARNING, "Duplicate default value definitions", element);

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
@@ -216,8 +216,7 @@ public abstract class ModelFileWriter<T extends Annotation> {
     }
 
     protected void initializePropertyGenerator(VariableElement e) {
-        PropertyGenerator generator = propertyGeneratorFactory
-                .getPropertyGeneratorForVariableElement(e, generatedClassName, modelSpecElement);
+        PropertyGenerator generator = propertyGeneratorForElement(e);
         if (generator != null) {
             if (generator.isDeprecated()) {
                 deprecatedPropertyGenerators.add(generator);
@@ -228,6 +227,11 @@ public abstract class ModelFileWriter<T extends Annotation> {
             utils.getMessager()
                     .printMessage(Kind.WARNING, "No PropertyGenerator found to handle this modelSpecElement", e);
         }
+    }
+
+    protected PropertyGenerator propertyGeneratorForElement(VariableElement e) {
+        return propertyGeneratorFactory
+                .getPropertyGeneratorForVariableElement(e, generatedClassName, modelSpecElement);
     }
 
     protected abstract void processVariableElement(VariableElement e, DeclaredTypeName elementType);

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
@@ -185,7 +185,7 @@ public class TableModelFileWriter extends ModelFileWriter<TableModelSpec> {
     private void emitGetIdPropertyMethod() throws IOException {
         writer.writeAnnotation(CoreTypes.OVERRIDE);
         MethodDeclarationParameters params = new MethodDeclarationParameters()
-                .setModifiers(Modifier.PROTECTED)
+                .setModifiers(Modifier.PUBLIC)
                 .setReturnType(TypeConstants.LONG_PROPERTY)
                 .setMethodName("getIdProperty");
         writer.beginMethodDefinition(params);

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
@@ -191,6 +191,7 @@ public class TableModelFileWriter extends ModelFileWriter<TableModelSpec> {
         } else {
             writer.writeStringStatement("return ID");
         }
+        writer.finishMethodDefinition();
         writer.writeNewline();
     }
 

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
@@ -160,7 +160,6 @@ public class TableModelFileWriter extends ModelFileWriter<TableModelSpec> {
             idPropertyGenerator.beforeEmitPropertyDeclaration(writer);
             idPropertyGenerator.emitPropertyDeclaration(writer);
             idPropertyGenerator.afterEmitPropertyDeclaration(writer);
-            writer.writeNewline();
         } else {
             // Default ID property
             Expression constructor;
@@ -174,9 +173,13 @@ public class TableModelFileWriter extends ModelFileWriter<TableModelSpec> {
             }
 
             writer.writeFieldDeclaration(TypeConstants.LONG_PROPERTY, "ID", constructor,
-                    TypeConstants.PUBLIC_STATIC_FINAL)
-                    .writeNewline();
+                    TypeConstants.PUBLIC_STATIC_FINAL);
         }
+        writer.beginInitializerBlock(true, true);
+        writer.writeStatement(Expressions.callMethodOn(TABLE_NAME, "setIdProperty",
+                idPropertyGenerator == null ? "ID" : idPropertyGenerator.getPropertyName()));
+        writer.finishInitializerBlock(true, true);
+        writer.writeNewline();
     }
 
     private void emitGetIdPropertyMethod() throws IOException {
@@ -192,7 +195,6 @@ public class TableModelFileWriter extends ModelFileWriter<TableModelSpec> {
             writer.writeStringStatement("return ID");
         }
         writer.finishMethodDefinition();
-        writer.writeNewline();
     }
 
     @Override

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
@@ -169,7 +169,7 @@ public class TableModelFileWriter extends ModelFileWriter<TableModelSpec> {
             } else {
                 constructor = Expressions.callConstructor(TypeConstants.LONG_PROPERTY, TABLE_NAME,
                         Expressions.staticReference(TypeConstants.TABLE_MODEL, "DEFAULT_ID_COLUMN"),
-                        "\"INTEGER PRIMARY KEY AUTOINCREMENT\"");
+                        "\"PRIMARY KEY AUTOINCREMENT\"");
             }
 
             writer.writeFieldDeclaration(TypeConstants.LONG_PROPERTY, "ID", constructor,

--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -11,6 +11,7 @@ import com.yahoo.squidb.sql.Criterion;
 import com.yahoo.squidb.sql.Property;
 import com.yahoo.squidb.test.DatabaseTestCase;
 import com.yahoo.squidb.test.TestModel;
+import com.yahoo.squidb.test.Thing;
 
 public class ModelTest extends DatabaseTestCase {
 
@@ -70,6 +71,25 @@ public class ModelTest extends DatabaseTestCase {
         // delete
         assertTrue(dao.delete(TestModel.class, id));
         assertEquals(0, dao.count(TestModel.class, Criterion.all));
+    }
+
+    public void testCrudMethodsWithNonDefaultPrimaryKey() {
+        Thing thing = new Thing();
+        dao.persist(thing);
+        assertEquals(1, thing.getId());
+
+        Thing fetched = dao.fetch(Thing.class, thing.getId(), Thing.PROPERTIES);
+        assertNotNull(fetched);
+
+        thing.setFoo("new foo");
+        dao.persist(thing);
+        fetched = dao.fetch(Thing.class, thing.getId(), Thing.PROPERTIES);
+        assertEquals("new foo", fetched.getFoo());
+        assertEquals(1, dao.count(Thing.class, Criterion.all));
+
+        // delete
+        assertTrue(dao.delete(Thing.class, thing.getId()));
+        assertEquals(0, dao.count(Thing.class, Criterion.all));
     }
 
     public void testDeprecatedPropertiesNotIncluded() {

--- a/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
@@ -18,7 +18,6 @@ public class PropertyTest extends SquidTestCase {
         LongProperty p = TestModel.ID;
         assertEquals(p.getExpression(), "testModels._id");
         assertEquals(p.getName(), "_id");
-        assertEquals(p.getQualifiedExpression(), "testModels._id AS _id");
 
         LongProperty basicAlias = p.as("newAlias");
         assertEquals(p.table, basicAlias.table);
@@ -41,8 +40,6 @@ public class PropertyTest extends SquidTestCase {
         LongProperty virtualP = TestVirtualModel.ID;
         assertEquals(virtualP.getExpression(), "virtual_models.rowid");
         assertEquals(virtualP.getName(), "rowid");
-        assertEquals(virtualP.getQualifiedExpression(), "virtual_models.rowid AS rowid");
-
     }
 
 }

--- a/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
@@ -10,11 +10,15 @@ import com.yahoo.squidb.sql.Query;
 import com.yahoo.squidb.test.SquidTestCase;
 import com.yahoo.squidb.test.TestModel;
 import com.yahoo.squidb.test.TestViewModel;
+import com.yahoo.squidb.test.TestVirtualModel;
 
 public class PropertyTest extends SquidTestCase {
 
     public void testPropertyAliasing() {
         LongProperty p = TestModel.ID;
+        assertEquals(p.getExpression(), "testModels._id");
+        assertEquals(p.getName(), "_id");
+        assertEquals(p.getQualifiedExpression(), "testModels._id AS _id");
 
         LongProperty basicAlias = p.as("newAlias");
         assertEquals(p.table, basicAlias.table);
@@ -33,6 +37,11 @@ public class PropertyTest extends SquidTestCase {
         assertEquals(basicAlias.getName(), asSelectionFromTable.getExpression());
         assertEquals("superAlias", asSelectionFromTable.getName());
         assertEquals("SELECT testView.newAlias AS superAlias", Query.select(asSelectionFromTable).toString());
+
+        LongProperty virtualP = TestVirtualModel.ID;
+        assertEquals(virtualP.getExpression(), "virtual_models.rowid");
+        assertEquals(virtualP.getName(), "rowid");
+        assertEquals(virtualP.getQualifiedExpression(), "virtual_models.rowid AS rowid");
 
     }
 

--- a/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
@@ -11,6 +11,7 @@ import com.yahoo.squidb.test.SquidTestCase;
 import com.yahoo.squidb.test.TestModel;
 import com.yahoo.squidb.test.TestViewModel;
 import com.yahoo.squidb.test.TestVirtualModel;
+import com.yahoo.squidb.test.Thing;
 
 public class PropertyTest extends SquidTestCase {
 
@@ -38,10 +39,13 @@ public class PropertyTest extends SquidTestCase {
         assertEquals("superAlias", asSelectionFromTable.getName());
         assertEquals("SELECT testView.newAlias AS superAlias", Query.select(asSelectionFromTable).toString());
 
-        LongProperty virtualP = TestVirtualModel.ID;
-        assertEquals(virtualP.getQualifiedExpression(), "virtual_models.rowid");
-        assertEquals(virtualP.getExpression(), "rowid");
-        assertEquals(virtualP.getName(), "rowid");
+        assertEquals(TestVirtualModel.ID.getQualifiedExpression(), "virtual_models.rowid");
+        assertEquals(TestVirtualModel.ID.getExpression(), "rowid");
+        assertEquals(TestVirtualModel.ID.getName(), "rowid");
+
+        assertEquals(Thing.ID.getQualifiedExpression(), "things.id");
+        assertEquals(Thing.ID.getExpression(), "id");
+        assertEquals(Thing.ID.getName(), "id");
     }
 
 }

--- a/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
@@ -16,7 +16,8 @@ public class PropertyTest extends SquidTestCase {
 
     public void testPropertyAliasing() {
         LongProperty p = TestModel.ID;
-        assertEquals(p.getExpression(), "testModels._id");
+        assertEquals(p.getQualifiedExpression(), "testModels._id");
+        assertEquals(p.getExpression(), "_id");
         assertEquals(p.getName(), "_id");
 
         LongProperty basicAlias = p.as("newAlias");
@@ -38,7 +39,8 @@ public class PropertyTest extends SquidTestCase {
         assertEquals("SELECT testView.newAlias AS superAlias", Query.select(asSelectionFromTable).toString());
 
         LongProperty virtualP = TestVirtualModel.ID;
-        assertEquals(virtualP.getExpression(), "virtual_models.rowid");
+        assertEquals(virtualP.getQualifiedExpression(), "virtual_models.rowid");
+        assertEquals(virtualP.getExpression(), "rowid");
         assertEquals(virtualP.getName(), "rowid");
     }
 

--- a/squidb-tests/src/com/yahoo/squidb/data/VirtualModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/VirtualModelTest.java
@@ -30,6 +30,12 @@ public class VirtualModelTest extends DatabaseTestCase {
         assertEquals(1, dao.count(TestVirtualModel.class, Criterion.all));
         assertEquals(1, dao.count(TestVirtualModel.class, TestVirtualModel.TITLE.eq("Charlie Brown")));
 
+        // update using setId on a template
+        TestVirtualModel model2 = new TestVirtualModel().setTitle("Charlie Brown 2").setId(model.getId());
+        assertTrue(dao.saveExisting(model2));
+        assertEquals(1, dao.count(TestVirtualModel.class, Criterion.all));
+        assertEquals(1, dao.count(TestVirtualModel.class, TestVirtualModel.TITLE.eq("Charlie Brown 2")));
+
         // delete
         assertTrue(dao.delete(TestVirtualModel.class, id));
         assertEquals(0, dao.count(TestVirtualModel.class, Criterion.all));

--- a/squidb-tests/src/com/yahoo/squidb/test/ThingSpec.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/ThingSpec.java
@@ -6,6 +6,7 @@
 package com.yahoo.squidb.test;
 
 import com.yahoo.squidb.annotations.ColumnSpec;
+import com.yahoo.squidb.annotations.PrimaryKey;
 import com.yahoo.squidb.annotations.TableModelSpec;
 
 @TableModelSpec(className = "Thing", tableName = "things")
@@ -14,6 +15,10 @@ public class ThingSpec {
     public static final String DEFAULT_FOO = "thing";
     public static final int DEFAULT_BAR = 100;
     public static final boolean DEFAULT_IS_ALIVE = true;
+
+    @PrimaryKey
+    @ColumnSpec(constraints = "PRIMARY KEY")
+    long id;
 
     @ColumnSpec(defaultValue = DEFAULT_FOO)
     String foo;

--- a/squidb-tests/src/com/yahoo/squidb/test/ThingSpec.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/ThingSpec.java
@@ -16,8 +16,7 @@ public class ThingSpec {
     public static final int DEFAULT_BAR = 100;
     public static final boolean DEFAULT_IS_ALIVE = true;
 
-    @PrimaryKey
-    @ColumnSpec(constraints = "PRIMARY KEY")
+    @PrimaryKey(autoincrement = false)
     long id;
 
     @ColumnSpec(defaultValue = DEFAULT_FOO)

--- a/squidb/src/com/yahoo/squidb/data/DatabaseDao.java
+++ b/squidb/src/com/yahoo/squidb/data/DatabaseDao.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.squidb.data;
 
+import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteTransactionListener;
 import android.net.Uri;
@@ -18,6 +19,7 @@ import com.yahoo.squidb.sql.Property;
 import com.yahoo.squidb.sql.Property.IntegerProperty;
 import com.yahoo.squidb.sql.Query;
 import com.yahoo.squidb.sql.SqlTable;
+import com.yahoo.squidb.sql.Table;
 import com.yahoo.squidb.sql.TableStatement.ConflictAlgorithm;
 import com.yahoo.squidb.sql.Update;
 
@@ -162,8 +164,8 @@ public class DatabaseDao {
      * @return true if delete was successful
      */
     public boolean delete(Class<? extends TableModel> modelClass, long id) {
-        SqlTable<?> table = getTableFrom(modelClass);
-        int rowsUpdated = database.delete(table.getExpression(), TableModel.ID_PROPERTY.eq(id).toRawSql(), null);
+        Table table = (Table) getTableFrom(modelClass);
+        int rowsUpdated = database.delete(table.getExpression(), table.getIdProperty().eq(id).toRawSql(), null);
         if (rowsUpdated > 0) {
             notifyForTable(DBOperation.DELETE, null, table, id);
         }
@@ -349,12 +351,15 @@ public class DatabaseDao {
         Class<? extends TableModel> modelClass = item.getClass();
         SqlTable<?> table = getTableFrom(modelClass);
         long newRow;
+        ContentValues mergedValues = item.getMergedValues();
+        if (mergedValues.size() == 0) {
+            return false;
+        }
         if (conflictAlgorithm == null) {
-            newRow = database.insert(table.getExpression(),
-                    TableModel.ID_PROPERTY_NAME, item.getMergedValues());
+            newRow = database.insert(table.getExpression(), null, mergedValues);
         } else {
-            newRow = database.insertWithOnConflict(table.getExpression(), TableModel.ID_PROPERTY_NAME,
-                    item.getMergedValues(), conflictAlgorithm.getAndroidValue());
+            newRow = database.insertWithOnConflict(table.getExpression(), null, mergedValues,
+                    conflictAlgorithm.getAndroidValue());
         }
         boolean result = newRow > 0;
         if (result) {
@@ -393,14 +398,14 @@ public class DatabaseDao {
         }
 
         Class<? extends TableModel> modelClass = item.getClass();
-        SqlTable<?> table = getTableFrom(modelClass);
+        Table table = (Table) getTableFrom(modelClass);
         boolean result;
         if (conflictAlgorithm == null) {
             result = database.update(table.getExpression(), item.getSetValues(),
-                    TableModel.ID_PROPERTY.eq(item.getId()).toRawSql(), null) > 0;
+                    table.getIdProperty().eq(item.getId()).toRawSql(), null) > 0;
         } else {
             result = database.updateWithOnConflict(table.getExpression(), item.getSetValues(),
-                    TableModel.ID_PROPERTY.eq(item.getId()).toRawSql(), null, conflictAlgorithm.getAndroidValue()) > 0;
+                    table.getIdProperty().eq(item.getId()).toRawSql(), null, conflictAlgorithm.getAndroidValue()) > 0;
         }
         if (result) {
             notifyForTable(DBOperation.UPDATE, item, table, item.getId());
@@ -575,7 +580,8 @@ public class DatabaseDao {
 
     protected <TYPE extends TableModel> SquidCursor<TYPE> fetchItemById(Class<TYPE> modelClass, long id,
             Property<?>... properties) {
-        return fetchFirstItem(modelClass, TableModel.ID_PROPERTY.eq(id), properties);
+        Table table = (Table) getTableFrom(modelClass);
+        return fetchFirstItem(modelClass, table.getIdProperty().eq(id), properties);
     }
 
     protected <TYPE extends AbstractModel> SquidCursor<TYPE> fetchFirstItem(Class<TYPE> modelClass,

--- a/squidb/src/com/yahoo/squidb/data/TableModel.java
+++ b/squidb/src/com/yahoo/squidb/data/TableModel.java
@@ -23,9 +23,6 @@ public abstract class TableModel extends AbstractModel {
     /** sentinel for objects without an id */
     public static final long NO_ID = 0;
 
-    /** id property common to all table based models */
-    protected static final String ID_PROPERTY_NAME = DEFAULT_ID_COLUMN;
-
     /**
      * Utility method to get the identifier of the model, if it exists.
      *

--- a/squidb/src/com/yahoo/squidb/data/TableModel.java
+++ b/squidb/src/com/yahoo/squidb/data/TableModel.java
@@ -71,5 +71,5 @@ public abstract class TableModel extends AbstractModel {
     /**
      * @return a {@link LongProperty to use as the integer primary key}
      */
-    protected abstract LongProperty getIdProperty();
+    public abstract LongProperty getIdProperty();
 }

--- a/squidb/src/com/yahoo/squidb/data/TableModel.java
+++ b/squidb/src/com/yahoo/squidb/data/TableModel.java
@@ -5,8 +5,6 @@
  */
 package com.yahoo.squidb.data;
 
-import android.content.ContentValues;
-
 import com.yahoo.squidb.sql.Property.LongProperty;
 import com.yahoo.squidb.sql.SqlTable;
 
@@ -39,17 +37,11 @@ public abstract class TableModel extends AbstractModel {
      * @return {@value #NO_ID} if this model was not added to the database
      */
     public long getId() {
-        Long id = null;
-        if (setValues != null && setValues.containsKey(ID_PROPERTY_NAME)) {
-            id = setValues.getAsLong(ID_PROPERTY_NAME);
-        } else if (values != null && values.containsKey(ID_PROPERTY_NAME)) {
-            id = values.getAsLong(ID_PROPERTY_NAME);
+        Long id = get(getIdProperty());
+        if (id == null) {
+            return NO_ID;
         }
-
-        if (id != null) {
-            return id;
-        }
-        return NO_ID;
+        return id;
     }
 
     /**
@@ -57,14 +49,10 @@ public abstract class TableModel extends AbstractModel {
      * @return this model instance, to allow chaining calls
      */
     public TableModel setId(long id) {
-        if (setValues == null) {
-            setValues = new ContentValues();
-        }
-
         if (id == NO_ID) {
             clearValue(ID_PROPERTY);
         } else {
-            setValues.put(ID_PROPERTY_NAME, id);
+            set(getIdProperty(), id);
         }
         return this;
     }
@@ -76,4 +64,8 @@ public abstract class TableModel extends AbstractModel {
         return getId() != NO_ID;
     }
 
+    /**
+     * @return a {@link LongProperty to use as the integer primary key}
+     */
+    protected abstract LongProperty getIdProperty();
 }

--- a/squidb/src/com/yahoo/squidb/data/TableModel.java
+++ b/squidb/src/com/yahoo/squidb/data/TableModel.java
@@ -6,7 +6,6 @@
 package com.yahoo.squidb.data;
 
 import com.yahoo.squidb.sql.Property.LongProperty;
-import com.yahoo.squidb.sql.SqlTable;
 
 /**
  * Represents a row in a SQLite table. Each model has an ID property that references the rowid in the table. This value
@@ -27,10 +26,6 @@ public abstract class TableModel extends AbstractModel {
     /** id property common to all table based models */
     protected static final String ID_PROPERTY_NAME = DEFAULT_ID_COLUMN;
 
-    /** id field common to all table based models */
-    public static final LongProperty ID_PROPERTY = new LongProperty((SqlTable<?>) null, ROWID,
-            ID_PROPERTY_NAME, null);
-
     /**
      * Utility method to get the identifier of the model, if it exists.
      *
@@ -50,7 +45,7 @@ public abstract class TableModel extends AbstractModel {
      */
     public TableModel setId(long id) {
         if (id == NO_ID) {
-            clearValue(ID_PROPERTY);
+            clearValue(getIdProperty());
         } else {
             set(getIdProperty(), id);
         }

--- a/squidb/src/com/yahoo/squidb/data/TableModel.java
+++ b/squidb/src/com/yahoo/squidb/data/TableModel.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.squidb.data;
 
+import android.content.ContentValues;
+
 import com.yahoo.squidb.sql.Property.LongProperty;
 
 /**
@@ -29,11 +31,18 @@ public abstract class TableModel extends AbstractModel {
      * @return {@value #NO_ID} if this model was not added to the database
      */
     public long getId() {
-        Long id = get(getIdProperty());
-        if (id == null) {
-            return NO_ID;
+        Long id = null;
+        String idPropertyName = getIdProperty().getName();
+        if (setValues != null && setValues.containsKey(idPropertyName)) {
+            id = setValues.getAsLong(idPropertyName);
+        } else if (values != null && values.containsKey(idPropertyName)) {
+            id = values.getAsLong(idPropertyName);
         }
-        return id;
+
+        if (id != null) {
+            return id;
+        }
+        return NO_ID;
     }
 
     /**
@@ -44,7 +53,10 @@ public abstract class TableModel extends AbstractModel {
         if (id == NO_ID) {
             clearValue(getIdProperty());
         } else {
-            set(getIdProperty(), id);
+            if (setValues == null) {
+                setValues = new ContentValues();
+            }
+            setValues.put(getIdProperty().getName(), id);
         }
         return this;
     }

--- a/squidb/src/com/yahoo/squidb/data/UriNotifier.java
+++ b/squidb/src/com/yahoo/squidb/data/UriNotifier.java
@@ -81,7 +81,7 @@ public abstract class UriNotifier {
      * Most UriNotifiers will probably not need all these parameters. For example:
      *
      * <pre>
-     * public void addUrisToNotify(Set<Uri> uris, SqlTable<?> table, String databaseName, DBOperation operation,
+     * public void addUrisToNotify(Set&lt;Uri&gt; uris, SqlTable&lt;?&gt; table, String databaseName, DBOperation operation,
      *     AbstractModel modelValues, long rowId) {
      *     // Notifies some constant Uri for any update on the students table
      *     if (Student.TABLE.equals(table)) {

--- a/squidb/src/com/yahoo/squidb/data/ViewModel.java
+++ b/squidb/src/com/yahoo/squidb/data/ViewModel.java
@@ -9,6 +9,7 @@ import com.yahoo.squidb.sql.Property;
 import com.yahoo.squidb.sql.Property.PropertyWritingVisitor;
 import com.yahoo.squidb.sql.Query;
 import com.yahoo.squidb.sql.SqlTable;
+import com.yahoo.squidb.sql.Table;
 import com.yahoo.squidb.sql.View;
 
 import java.util.ArrayList;
@@ -169,7 +170,7 @@ public abstract class ViewModel extends AbstractModel {
             String name = base.getName();
             if (duplicates.contains(name)) {
                 String alias;
-                if (TableModel.ID_PROPERTY_NAME.equals(name) && base.table != null) {
+                if (base.table instanceof Table && ((Table) base.table).getIdProperty().equals(base)) {
                     alias = base.table.getName() + "Id";
                 } else {
                     int occurence = numOccurences.get(name);

--- a/squidb/src/com/yahoo/squidb/sql/Criterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/Criterion.java
@@ -25,7 +25,7 @@ import java.util.List;
  * Person.AGE.gte(18).and(Person.IS_EMPLOYED.isTrue()) // person.age &gt;= 18 AND person.is_employed &lt;&gt; 0
  * Person.NUM_SIBLINGS.neq(0).or(Person.NUM_PETS.neq(0)) // person.num_siblings &lt;&gt; 0 OR person.num_pets &lt;&gt; 0
  *
- * Person.AGE.gte(18).negate() // person.age < 18
+ * Person.AGE.gte(18).negate() // person.age &lt; 18
  * Person.ID.in(1,2,3).negate() // NOT person._id IN (1,2,3)
  * </pre>
  *

--- a/squidb/src/com/yahoo/squidb/sql/Operator.java
+++ b/squidb/src/com/yahoo/squidb/sql/Operator.java
@@ -14,19 +14,19 @@ import java.util.Map;
 public enum Operator {
     /** EQUALS ('=') */
     eq("="),
-    /** NOT EQUALS ('<>') */
+    /** NOT EQUALS ('&gt;&lt;') */
     neq("<>"),
     /** IS */
     is(" IS "),
     /** IS NOT */
     isNot(" IS NOT "),
-    /** GREATER THAN ('>') */
+    /** GREATER THAN ('&gt;') */
     gt(">"),
-    /** LESS THAN ('<') */
+    /** LESS THAN ('&lt;') */
     lt("<"),
-    /** GREATER THAN OR EQUAL ('>=') */
+    /** GREATER THAN OR EQUAL ('&gt;=') */
     gte(">="),
-    /** LESS THAN OR EQUAL ('<=') */
+    /** LESS THAN OR EQUAL ('&lt;=') */
     lte("<="),
     /** AND */
     and(" AND "),

--- a/squidb/src/com/yahoo/squidb/sql/Table.java
+++ b/squidb/src/com/yahoo/squidb/sql/Table.java
@@ -94,9 +94,13 @@ public class Table extends SqlTable<TableModel> {
      */
     public void appendCreateTableSql(StringBuilder sql, PropertyVisitor<Void, StringBuilder> propertyVisitor) {
         sql.append("CREATE TABLE IF NOT EXISTS ").append(getExpression()).append('(');
+        boolean needsComma = false;
         for (Property<?> property : properties) {
-            sql.append(',');
+            if (needsComma) {
+                sql.append(", ");
+            }
             property.accept(propertyVisitor, sql);
+            needsComma = true;
         }
         if (!TextUtils.isEmpty(getTableConstraint())) {
             sql.append(", ").append(getTableConstraint());

--- a/squidb/src/com/yahoo/squidb/sql/Table.java
+++ b/squidb/src/com/yahoo/squidb/sql/Table.java
@@ -93,12 +93,8 @@ public class Table extends SqlTable<TableModel> {
      * this method and instead let {@link AbstractDatabase} build tables automatically.
      */
     public void appendCreateTableSql(StringBuilder sql, PropertyVisitor<Void, StringBuilder> propertyVisitor) {
-        sql.append("CREATE TABLE IF NOT EXISTS ").append(getExpression()).append('(').
-                append(TableModel.DEFAULT_ID_COLUMN).append(" INTEGER PRIMARY KEY AUTOINCREMENT");
+        sql.append("CREATE TABLE IF NOT EXISTS ").append(getExpression()).append('(');
         for (Property<?> property : properties) {
-            if (TableModel.DEFAULT_ID_COLUMN.equals(property.getExpression())) {
-                continue;
-            }
             sql.append(',');
             property.accept(propertyVisitor, sql);
         }

--- a/squidb/src/com/yahoo/squidb/sql/Table.java
+++ b/squidb/src/com/yahoo/squidb/sql/Table.java
@@ -9,6 +9,7 @@ import android.text.TextUtils;
 
 import com.yahoo.squidb.data.AbstractDatabase;
 import com.yahoo.squidb.data.TableModel;
+import com.yahoo.squidb.sql.Property.LongProperty;
 import com.yahoo.squidb.sql.Property.PropertyVisitor;
 
 /**
@@ -17,6 +18,7 @@ import com.yahoo.squidb.sql.Property.PropertyVisitor;
 public class Table extends SqlTable<TableModel> {
 
     private final String tableConstraint;
+    private LongProperty idProperty;
 
     public Table(Class<? extends TableModel> modelClass, Property<?>[] properties, String name) {
         this(modelClass, properties, name, null);
@@ -104,5 +106,28 @@ public class Table extends SqlTable<TableModel> {
             sql.append(", ").append(getTableConstraint());
         }
         sql.append(')');
+    }
+
+    /**
+     * Sets the primary key column for this table. Do not call this method! Exposed only so that it can be set
+     * when initializing a model class.
+     *
+     * @param idProperty a LongProperty representing the table's primary key id column
+     */
+    public void setIdProperty(LongProperty idProperty) {
+        if (idProperty != null) {
+            throw new UnsupportedOperationException("Can't call setIdProperty on a Table more than once");
+        }
+        this.idProperty = idProperty;
+    }
+
+    /**
+     * @return the property representing the table's primary key id column
+     */
+    public LongProperty getIdProperty() {
+        if (idProperty == null) {
+            throw new UnsupportedOperationException("Table " + getExpression() + " has no id property defined");
+        }
+        return idProperty;
     }
 }

--- a/squidb/src/com/yahoo/squidb/sql/Table.java
+++ b/squidb/src/com/yahoo/squidb/sql/Table.java
@@ -111,7 +111,7 @@ public class Table extends SqlTable<TableModel> {
      * @param idProperty a LongProperty representing the table's primary key id column
      */
     public void setIdProperty(LongProperty idProperty) {
-        if (idProperty != null) {
+        if (this.idProperty != null) {
             throw new UnsupportedOperationException("Can't call setIdProperty on a Table more than once");
         }
         this.idProperty = idProperty;

--- a/squidb/src/com/yahoo/squidb/utility/SquidCursorAdapter.java
+++ b/squidb/src/com/yahoo/squidb/utility/SquidCursorAdapter.java
@@ -12,8 +12,8 @@ import android.widget.BaseAdapter;
 
 import com.yahoo.squidb.data.AbstractModel;
 import com.yahoo.squidb.data.SquidCursor;
-import com.yahoo.squidb.data.TableModel;
 import com.yahoo.squidb.sql.Property;
+import com.yahoo.squidb.sql.SqlTable;
 
 /**
  * A base {@link Adapter} implementation backed by a {@link SquidCursor}. Subclass implementations typically supply a
@@ -43,6 +43,10 @@ public abstract class SquidCursorAdapter<T extends AbstractModel> extends BaseAd
     private final T model;
     private final Property<Long> columnForId;
 
+    /** Property for default "_id" name */
+    private static final Property<Long> ID_PROPERTY = new Property.LongProperty((SqlTable<?>) null,
+            "_id", null);
+
     /**
      * Equivalent to SquidCursorAdapter(context, model, null). Should be used for TableModel cursors where the _id
      * column is present.
@@ -50,7 +54,7 @@ public abstract class SquidCursorAdapter<T extends AbstractModel> extends BaseAd
      * @param model an instance of the model type to use for this cursor. See note at the top of this file.
      */
     public SquidCursorAdapter(Context context, T model) {
-        this(context, model, null);
+        this(context, model, ID_PROPERTY);
     }
 
     /**
@@ -132,9 +136,8 @@ public abstract class SquidCursorAdapter<T extends AbstractModel> extends BaseAd
 
     @Override
     public long getItemId(int position) {
-        Property<Long> idProperty = columnForId != null ? columnForId : TableModel.ID_PROPERTY;
         if (cursor != null && cursor.moveToPosition(position)) {
-            return cursor.get(idProperty);
+            return cursor.get(columnForId);
         }
         return 0;
     }

--- a/squidb/src/com/yahoo/squidb/utility/SquidCursorAdapter.java
+++ b/squidb/src/com/yahoo/squidb/utility/SquidCursorAdapter.java
@@ -12,6 +12,7 @@ import android.widget.BaseAdapter;
 
 import com.yahoo.squidb.data.AbstractModel;
 import com.yahoo.squidb.data.SquidCursor;
+import com.yahoo.squidb.data.TableModel;
 import com.yahoo.squidb.sql.Property;
 import com.yahoo.squidb.sql.SqlTable;
 
@@ -45,7 +46,7 @@ public abstract class SquidCursorAdapter<T extends AbstractModel> extends BaseAd
 
     /** Property for default "_id" name */
     private static final Property<Long> ID_PROPERTY = new Property.LongProperty((SqlTable<?>) null,
-            "_id", null);
+            TableModel.DEFAULT_ID_COLUMN, null);
 
     /**
      * Equivalent to SquidCursorAdapter(context, model, null). Should be used for TableModel cursors where the _id

--- a/squidb/src/com/yahoo/squidb/utility/SquidCursorAdapter.java
+++ b/squidb/src/com/yahoo/squidb/utility/SquidCursorAdapter.java
@@ -70,7 +70,7 @@ public abstract class SquidCursorAdapter<T extends AbstractModel> extends BaseAd
         this.context = context;
         this.inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         this.model = model;
-        this.columnForId = columnForId;
+        this.columnForId = columnForId != null ? columnForId : ID_PROPERTY;
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/utility/SquidCursorAdapter.java
+++ b/squidb/src/com/yahoo/squidb/utility/SquidCursorAdapter.java
@@ -55,7 +55,7 @@ public abstract class SquidCursorAdapter<T extends AbstractModel> extends BaseAd
      * @param model an instance of the model type to use for this cursor. See note at the top of this file.
      */
     public SquidCursorAdapter(Context context, T model) {
-        this(context, model, ID_PROPERTY);
+        this(context, model, model instanceof TableModel ? ((TableModel) model).getIdProperty() : ID_PROPERTY);
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/utility/VersionCode.java
+++ b/squidb/src/com/yahoo/squidb/utility/VersionCode.java
@@ -113,14 +113,14 @@ public class VersionCode implements Comparable<VersionCode> {
      * minor or micro version is considered to be 0.
      *
      * <pre>
-     * "1"              =>  1.0.0
-     * "1.2"            =>  1.2.0
-     * "1.2.3"          =>  1.2.3
-     * "1.2.3foo"       =>  1.2.3foo
-     * "1.2.3foo bar"   =>  1.2.3foo
-     * "1foo"           =>  1.0.0foo
-     * "1.2foo"         =>  1.2.0foo
-     * "foo"            =>  0.0.0
+     * "1"              =&lt;  1.0.0
+     * "1.2"            =&lt;  1.2.0
+     * "1.2.3"          =&lt;  1.2.3
+     * "1.2.3foo"       =&lt;  1.2.3foo
+     * "1.2.3foo bar"   =&lt;  1.2.3foo
+     * "1foo"           =&lt;  1.0.0foo
+     * "1.2foo"         =&lt;  1.2.0foo
+     * "foo"            =&lt;  0.0.0
      * </pre>
      *
      * @throws IllegalArgumentException if the input cannot be parsed.


### PR DESCRIPTION
This PR introduces a new annotation, PrimaryKey, which will allow users to customize their column definitions for primary keys. At this time, only INTEGER PRIMARY KEYs are supported, but the following things are now possible:
 * Name the primary key column anything you want. Helps with backwards compatibility and closes #27 
 * Disable the AUTOINCREMENT behavior which was previously required
 * Fixes setId behavior for virtual table models (half of #23)

I think this PR also lays some groundwork for multi-column primary key support in the future, but I'm not quite ready to tackle that.