### PR TITLE
Hack for handling null characters in inlined string literals

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/sql/SqlUtilsTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/SqlUtilsTest.java
@@ -48,12 +48,15 @@ public class SqlUtilsTest extends DatabaseTestCase {
 
     public void testSanitizeString() {
         assertEquals("'Sam''s'", SqlUtils.toSanitizedString("Sam's"));
+        assertEquals("CAST(x'00' AS TEXT)", SqlUtils.toSanitizedString("\0"));
         assertEquals("CAST(x'00' AS TEXT) || 'ABC'", SqlUtils.toSanitizedString("\0ABC"));
         assertEquals("CAST(x'00' AS TEXT) || 'A' || CAST(x'00' AS TEXT) || 'B''C'",
                 SqlUtils.toSanitizedString("\0A\0B'C"));
         assertEquals("CAST(x'00' AS TEXT) || 'ABC' || CAST(x'00' AS TEXT)", SqlUtils.toSanitizedString("\0ABC\0"));
         assertEquals("'A' || CAST(x'00' AS TEXT) || 'BC' || CAST(x'00' AS TEXT)",
                 SqlUtils.toSanitizedString("A\0BC\0"));
+        assertEquals("'A' || CAST(x'00' AS TEXT) || 'B' || CAST(x'00' AS TEXT) || 'C'",
+                SqlUtils.toSanitizedString("A\0B\0C"));
         assertEquals("'ABC' || CAST(x'00' AS TEXT)", SqlUtils.toSanitizedString("ABC\0"));
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/CompiledArgumentResolver.java
+++ b/squidb/src/com/yahoo/squidb/sql/CompiledArgumentResolver.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.squidb.sql;
 
+import android.util.Log;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -98,6 +100,10 @@ class CompiledArgumentResolver {
             String resultSql = result.toString();
             if (!largeArgMode) {
                 compiledSqlCache.put(cacheKey, resultSql);
+            } else {
+                Log.w("squidb", "The SQL statement \"" + resultSql.substring(0, Math.min(200, resultSql.length()))
+                        + " ...\" had too many arguments to bind, so arguments were inlined into the SQL instead."
+                        + " Consider revising your statement to have fewer arguments.");
             }
             return resultSql;
         } else {

--- a/squidb/src/com/yahoo/squidb/sql/SqlUtils.java
+++ b/squidb/src/com/yahoo/squidb/sql/SqlUtils.java
@@ -99,10 +99,10 @@ public class SqlUtils {
      */
     private static String sanitizeStringAsLiteral(String literal) {
         String sanitizedLiteral = literal.replace("'", "''");
-        if (sanitizedLiteral.contains("\0")) {
+        int nullIndex = sanitizedLiteral.indexOf('\0');
+        if (nullIndex >= 0) {
             StringBuilder builder = new StringBuilder();
             int start = 0;
-            int nullIndex = sanitizedLiteral.indexOf('\0');
             while (nullIndex >= 0) {
                 String substr = sanitizedLiteral.substring(start, nullIndex);
                 if (substr.length() > 0) { // Append sanitized component before the null

--- a/squidb/src/com/yahoo/squidb/sql/SqlUtils.java
+++ b/squidb/src/com/yahoo/squidb/sql/SqlUtils.java
@@ -108,7 +108,13 @@ public class SqlUtils {
                 if (substr.length() > 0) { // Append sanitized component before the null
                     builder.append("'").append(substr).append("' || ");
                 }
-                builder.append("CAST(x'00' AS TEXT)"); // Append escaped null character
+                builder.append("CAST(x'00");
+                while (nullIndex + 1 < sanitizedLiteral.length() &&
+                        sanitizedLiteral.charAt(nullIndex + 1) == '\0') { // If there are many adjacent nulls, combine
+                    builder.append("00");
+                    nullIndex++;
+                }
+                builder.append("' AS TEXT)"); // Close the cast
                 start = nullIndex + 1;
                 if (start < sanitizedLiteral.length()) { // If there's more left, continue concatenating
                     builder.append(" || ");


### PR DESCRIPTION
Java treats strings differently than C does. In Java, null characters are allowed. In C, they end the string. So if we inline a Java string that contains null characters as a literal, the SQL parsing will just fail when Android passes it to the native SQLite library. Of course, the best option is to bind all such strings as arguments rather than inlining them, but when there are too many arguments (like in a large IN criterion), we fall back to inlining, so we need a fallback for inlined string literals too. This commit enhances string literal sanitization to replace occurrences of null characters with SQL string concatenations of CAST(x'00' AS TEXT), which converts a literal blob of the null character to a string.