### PR TITLE
Random fixes

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/sql/QueryTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/QueryTest.java
@@ -354,6 +354,28 @@ public class QueryTest extends DatabaseTestCase {
         }
     }
 
+    public void testReusableQueryWithAtomicBoolean() {
+        AtomicBoolean bool = new AtomicBoolean(false);
+        Query query = Query.select().where(Employee.IS_HAPPY.eq(bool));
+
+        SquidCursor<Employee> cursor = dao.query(Employee.class, query);
+        try {
+            assertEquals(1, cursor.getCount());
+            cursor.moveToFirst();
+            assertEquals(oscar.getId(), cursor.get(Employee.ID).longValue());
+        } finally {
+            cursor.close();
+        }
+
+        bool.set(true);
+        cursor = dao.query(Employee.class, query);
+        try {
+            assertEquals(5, cursor.getCount());
+        } finally {
+            cursor.close();
+        }
+    }
+
     public void testAtomicIntegers() {
         AtomicInteger id = new AtomicInteger(1);
         Query query = Query.select(Employee.ID).where(Employee.ID.eq(id));

--- a/squidb-tests/src/com/yahoo/squidb/sql/SqlUtilsTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/SqlUtilsTest.java
@@ -48,21 +48,23 @@ public class SqlUtilsTest extends DatabaseTestCase {
 
     public void testSanitizeString() {
         assertEquals("'Sam''s'", SqlUtils.toSanitizedString("Sam's"));
-        assertEquals("CAST(x'00' AS TEXT)", SqlUtils.toSanitizedString("\0"));
-        assertEquals("CAST(x'0000' AS TEXT)", SqlUtils.toSanitizedString("\0\0"));
-        assertEquals("CAST(x'00' AS TEXT) || 'ABC'", SqlUtils.toSanitizedString("\0ABC"));
-        assertEquals("CAST(x'0000' AS TEXT) || 'ABC'", SqlUtils.toSanitizedString("\0\0ABC"));
-        assertEquals("CAST(x'00' AS TEXT) || 'A' || CAST(x'00' AS TEXT) || 'B''C'",
+        assertEquals("CAST(ZEROBLOB(1) AS TEXT)", SqlUtils.toSanitizedString("\0"));
+        assertEquals("CAST(ZEROBLOB(2) AS TEXT)", SqlUtils.toSanitizedString("\0\0"));
+        assertEquals("CAST(ZEROBLOB(1) AS TEXT) || 'ABC'", SqlUtils.toSanitizedString("\0ABC"));
+        assertEquals("CAST(ZEROBLOB(2) AS TEXT) || 'ABC'", SqlUtils.toSanitizedString("\0\0ABC"));
+        assertEquals("CAST(ZEROBLOB(1) AS TEXT) || 'A' || CAST(ZEROBLOB(1) AS TEXT) || 'B''C'",
                 SqlUtils.toSanitizedString("\0A\0B'C"));
-        assertEquals("CAST(x'00' AS TEXT) || 'ABC' || CAST(x'00' AS TEXT)", SqlUtils.toSanitizedString("\0ABC\0"));
-        assertEquals("CAST(x'00' AS TEXT) || 'ABC' || CAST(x'0000' AS TEXT)", SqlUtils.toSanitizedString("\0ABC\0\0"));
-        assertEquals("'A' || CAST(x'00' AS TEXT) || 'BC' || CAST(x'00' AS TEXT)",
+        assertEquals("CAST(ZEROBLOB(1) AS TEXT) || 'ABC' || CAST(ZEROBLOB(1) AS TEXT)",
+                SqlUtils.toSanitizedString("\0ABC\0"));
+        assertEquals("CAST(ZEROBLOB(1) AS TEXT) || 'ABC' || CAST(ZEROBLOB(2) AS TEXT)",
+                SqlUtils.toSanitizedString("\0ABC\0\0"));
+        assertEquals("'A' || CAST(ZEROBLOB(1) AS TEXT) || 'BC' || CAST(ZEROBLOB(1) AS TEXT)",
                 SqlUtils.toSanitizedString("A\0BC\0"));
-        assertEquals("'A' || CAST(x'0000' AS TEXT) || 'BC' || CAST(x'00' AS TEXT)",
+        assertEquals("'A' || CAST(ZEROBLOB(2) AS TEXT) || 'BC' || CAST(ZEROBLOB(1) AS TEXT)",
                 SqlUtils.toSanitizedString("A\0\0BC\0"));
-        assertEquals("'A' || CAST(x'00' AS TEXT) || 'B' || CAST(x'00' AS TEXT) || 'C'",
+        assertEquals("'A' || CAST(ZEROBLOB(1) AS TEXT) || 'B' || CAST(ZEROBLOB(1) AS TEXT) || 'C'",
                 SqlUtils.toSanitizedString("A\0B\0C"));
-        assertEquals("'ABC' || CAST(x'00' AS TEXT)", SqlUtils.toSanitizedString("ABC\0"));
+        assertEquals("'ABC' || CAST(ZEROBLOB(1) AS TEXT)", SqlUtils.toSanitizedString("ABC\0"));
     }
 
     public void testDatabaseWriteWithNullCharactersWorks() {

--- a/squidb/src/com/yahoo/squidb/sql/CompiledArgumentResolver.java
+++ b/squidb/src/com/yahoo/squidb/sql/CompiledArgumentResolver.java
@@ -174,12 +174,7 @@ class CompiledArgumentResolver {
                     }
                 }
             } else {
-                if (arg instanceof AtomicBoolean) { // Not a subclass of number so needs special handling
-                    foundReferenceArgument = true;
-                    compiledArgs[i] = ((AtomicBoolean) arg).get() ? 1 : 0;
-                } else {
-                    compiledArgs[i] = arg;
-                }
+                compiledArgs[i] = arg;
                 i++;
             }
         }

--- a/squidb/src/com/yahoo/squidb/sql/SqlUtils.java
+++ b/squidb/src/com/yahoo/squidb/sql/SqlUtils.java
@@ -108,13 +108,14 @@ public class SqlUtils {
                 if (substr.length() > 0) { // Append sanitized component before the null
                     builder.append("'").append(substr).append("' || ");
                 }
-                builder.append("CAST(x'00");
+                builder.append("CAST(ZEROBLOB(");
+                int blobLength = 1;
                 while (nullIndex + 1 < sanitizedLiteral.length() &&
                         sanitizedLiteral.charAt(nullIndex + 1) == '\0') { // If there are many adjacent nulls, combine
-                    builder.append("00");
+                    blobLength++;
                     nullIndex++;
                 }
-                builder.append("' AS TEXT)"); // Close the cast
+                builder.append(blobLength).append(") AS TEXT)"); // Close the cast
                 start = nullIndex + 1;
                 if (start < sanitizedLiteral.length()) { // If there's more left, continue concatenating
                     builder.append(" || ");

--- a/squidb/src/com/yahoo/squidb/utility/SquidCursorAdapter.java
+++ b/squidb/src/com/yahoo/squidb/utility/SquidCursorAdapter.java
@@ -31,7 +31,7 @@ import com.yahoo.squidb.sql.SqlTable;
  * using {@link AbstractModel#readPropertiesFromCursor(SquidCursor) readPropertiesFromCursor}, or read values from the
  * backing cursor directly.
  *
- * By default, {@link #hasStableIds()} returns false. You should override it to return true if your adapter will have
+ * By default, {@link #hasStableIds()} returns true. You should override it to return true if your adapter will not have
  * stable ids.
  *
  * @param <T> the model type of the SquidCursor backing this adapter
@@ -141,6 +141,11 @@ public abstract class SquidCursorAdapter<T extends AbstractModel> extends BaseAd
             return cursor.get(columnForId);
         }
         return 0;
+    }
+
+    @Override
+    public boolean hasStableIds() {
+        return true;
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/utility/SquidCursorFactory.java
+++ b/squidb/src/com/yahoo/squidb/utility/SquidCursorFactory.java
@@ -16,6 +16,8 @@ import android.database.sqlite.SQLiteProgram;
 import android.database.sqlite.SQLiteQuery;
 import android.os.Build;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * A custom cursor factory that ensures query arguments are bound as their native types, rather than as strings. The
  * {@link com.yahoo.squidb.data.AbstractDatabase AbstractDatabase} documentation notes why this is important.
@@ -50,6 +52,9 @@ public class SquidCursorFactory implements CursorFactory {
         }
         for (int i = 1; i <= sqlArgs.length; i++) {
             Object arg = sqlArgs[i - 1];
+            if (arg instanceof AtomicBoolean) { // Not a subclass of Number so DatabaseUtils won't handle it
+                arg = ((AtomicBoolean) arg).get() ? 1 : 0;
+            }
             DatabaseUtils.bindObjectToProgram(program, i, arg);
         }
     }


### PR DESCRIPTION
None of these are super critical, they're mostly just micro optimizations.
* Handle AtomicBooleans at argument binding time rather than treating them as reference arguments like we already do for things like AtomicLong/Integer (which are subclasses of Number).
* SquidCursorAdapter.hasStableIds should return true by default.
* Use the zeroblob() function for escaping null characters in inlined strings rather than blob literals. Supposedly SQLite handles zeroblobs very efficiently.