### PR TITLE
Universal data changed notifier [2.0]

### DIFF
--- a/squidb-sample/src/main/java/com/yahoo/squidb/sample/modules/HelloSquiDBModule.java
+++ b/squidb-sample/src/main/java/com/yahoo/squidb/sample/modules/HelloSquiDBModule.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.net.Uri;
 
 import com.yahoo.squidb.data.AbstractModel;
+import com.yahoo.squidb.data.SquidDatabase;
 import com.yahoo.squidb.data.UriNotifier;
 import com.yahoo.squidb.sample.HelloSquiDBApplication;
 import com.yahoo.squidb.sample.TaskListActivity;
@@ -40,16 +41,17 @@ public class HelloSquiDBModule {
     }
 
     @Provides
-    @Singleton // We want the database instance to be a singleton
+    @Singleton
+        // We want the database instance to be a singleton
     TasksDatabase provideTasksDatabase(@ForApplicaton Context context) {
         TasksDatabase database = new TasksDatabase(context);
 
         // Setting up a UriNotifier will sent ContentObserver notifications to Uris on table writes
-        database.registerUriNotifier(new UriNotifier(Task.TABLE, Tag.TABLE) {
+        database.registerDataChangedNotifier(new UriNotifier(Task.TABLE, Tag.TABLE) {
             @Override
-            public void addUrisToNotify(Set<Uri> uris, SqlTable<?> table, String databaseName,
+            protected boolean accumulateNotificationObjects(Set<Uri> uris, SqlTable<?> table, SquidDatabase database,
                     DBOperation operation, AbstractModel modelValues, long rowId) {
-                uris.add(Task.CONTENT_URI);
+                return uris.add(Task.CONTENT_URI);
             }
         });
         return database;

--- a/squidb-tests/src/com/yahoo/squidb/data/DataChangedNotifierTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/DataChangedNotifierTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.data;
+
+import android.text.format.DateUtils;
+
+import com.yahoo.squidb.sql.Delete;
+import com.yahoo.squidb.sql.Insert;
+import com.yahoo.squidb.sql.SqlTable;
+import com.yahoo.squidb.sql.Update;
+import com.yahoo.squidb.test.DatabaseTestCase;
+import com.yahoo.squidb.test.Employee;
+import com.yahoo.squidb.test.TestModel;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DataChangedNotifierTest extends DatabaseTestCase {
+
+    private static class TestDataChangedNotifier extends DataChangedNotifier<TestDataChangedNotifier> {
+
+        private boolean accumulateCalled = false;
+        private boolean sendNotificationCalled = false;
+
+        @Override
+        protected boolean accumulateNotificationObjects(Set<TestDataChangedNotifier> accumulatorSet, SqlTable<?> table,
+                SquidDatabase database, DBOperation operation, AbstractModel modelValues, long rowId) {
+            accumulateCalled = true;
+            return accumulatorSet.add(this);
+        }
+
+        @Override
+        protected void sendNotification(SquidDatabase database, TestDataChangedNotifier notifyObject) {
+            sendNotificationCalled = true;
+            assertTrue(notifyObject == this);
+        }
+
+        private void reset() {
+            accumulateCalled = sendNotificationCalled = false;
+        }
+    }
+
+    public void testRegisterAndUnregister() {
+        TestDataChangedNotifier notifier = new TestDataChangedNotifier();
+        database.registerDataChangedNotifier(notifier);
+
+        TestModel t1 = insertBasicTestModel();
+        assertTrue(notifier.accumulateCalled);
+        assertTrue(notifier.sendNotificationCalled);
+
+        notifier.reset();
+        database.unregisterDataChangedNotifier(notifier);
+        database.delete(TestModel.class, t1.getId());
+        assertFalse(notifier.accumulateCalled);
+        assertFalse(notifier.sendNotificationCalled);
+    }
+
+    public void testInsert() {
+        final TestModel t1 = new TestModel().setFirstName("Sam").setLastName("Bosley")
+                .setBirthday(System.currentTimeMillis() - 1);
+        final TestModel t2 = new TestModel().setFirstName("Jon").setLastName("Koren")
+                .setBirthday(System.currentTimeMillis());
+        Runnable toRun = new Runnable() {
+            @Override
+            public void run() {
+                database.createNew(t1);
+            }
+        };
+        testForParameters(toRun, TestModel.TABLE, DataChangedNotifier.DBOperation.INSERT, t1, 1L);
+
+        toRun = new Runnable() {
+            @Override
+            public void run() {
+                database.createNew(t2);
+            }
+        };
+        testForParameters(toRun, TestModel.TABLE, DataChangedNotifier.DBOperation.INSERT, t2, 2L);
+
+        toRun = new Runnable() {
+            public void run() {
+                database.insert(Insert.into(TestModel.TABLE).columns(TestModel.FIRST_NAME, TestModel.LAST_NAME)
+                        .values("Some", "Guy"));
+            }
+        };
+
+        testForParameters(toRun, TestModel.TABLE, DataChangedNotifier.DBOperation.INSERT, null, 3);
+    }
+
+    public void testUpdate() {
+        final TestModel t1 = insertBasicTestModel();
+        Runnable toRun = new Runnable() {
+            @Override
+            public void run() {
+                t1.setLastName("Boss");
+                database.persist(t1);
+            }
+        };
+        testForParameters(toRun, TestModel.TABLE, DataChangedNotifier.DBOperation.UPDATE, t1, t1.getId());
+
+        insertBasicTestModel("Sam", "Bosley", System.currentTimeMillis());
+        final TestModel template = new TestModel().setFirstName("The");
+        toRun = new Runnable() {
+            @Override
+            public void run() {
+                database.update(TestModel.LAST_NAME.like("Bos%"), template);
+            }
+        };
+        testForParameters(toRun, TestModel.TABLE, DataChangedNotifier.DBOperation.UPDATE, template, 0);
+
+        toRun = new Runnable() {
+            @Override
+            public void run() {
+                database.update(Update.table(TestModel.TABLE).fromTemplate(new TestModel().setFirstName("Guy"))
+                        .where(TestModel.LAST_NAME.like("Bos%")));
+            }
+        };
+        testForParameters(toRun, TestModel.TABLE, DataChangedNotifier.DBOperation.UPDATE, null, 0);
+    }
+
+    public void testDelete() {
+        final TestModel t1 = insertBasicTestModel();
+        Runnable toRun = new Runnable() {
+            @Override
+            public void run() {
+                database.delete(TestModel.class, t1.getId());
+            }
+        };
+        testForParameters(toRun, TestModel.TABLE, DataChangedNotifier.DBOperation.DELETE, null, t1.getId());
+
+        insertBasicTestModel("Sam", "Bosley", System.currentTimeMillis());
+        toRun = new Runnable() {
+            @Override
+            public void run() {
+                database.deleteWhere(TestModel.class, TestModel.LAST_NAME.like("Bos%"));
+            }
+        };
+        testForParameters(toRun, TestModel.TABLE, DataChangedNotifier.DBOperation.DELETE, null, 0);
+
+        insertBasicTestModel("Sam", "Bosley", System.currentTimeMillis() + DateUtils.DAY_IN_MILLIS);
+        toRun = new Runnable() {
+            @Override
+            public void run() {
+                database.delete(Delete.from(TestModel.TABLE).where(TestModel.LAST_NAME.like("Bos%")));
+            }
+        };
+        testForParameters(toRun, TestModel.TABLE, DataChangedNotifier.DBOperation.DELETE, null, 0);
+    }
+
+    private void testForParameters(Runnable execute, final SqlTable<?> expectedTable, final DataChangedNotifier.DBOperation expectedOp,
+            final AbstractModel expectedModel, final long expectedRowId) {
+        TestDataChangedNotifier notifier = new TestDataChangedNotifier() {
+            @Override
+            protected boolean accumulateNotificationObjects(Set<TestDataChangedNotifier> accumulatorSet, SqlTable<?> table,
+                    SquidDatabase database, DataChangedNotifier.DBOperation operation, AbstractModel modelValues, long rowId) {
+                assertEquals(expectedTable, table);
+                assertEquals(expectedOp, operation);
+                assertEquals(expectedModel, modelValues);
+                assertEquals(expectedRowId, rowId);
+                return super.accumulateNotificationObjects(accumulatorSet, table, database, operation,
+                        modelValues, rowId);
+            }
+        };
+        database.registerDataChangedNotifier(notifier);
+        execute.run();
+        assertTrue(notifier.accumulateCalled);
+        database.unregisterDataChangedNotifier(notifier);
+    }
+
+    public void testMultipleNotifiersCanBeRegistered() {
+        TestDataChangedNotifier n1 = new TestDataChangedNotifier();
+        TestDataChangedNotifier n2 = new TestDataChangedNotifier();
+
+        database.registerDataChangedNotifier(n1);
+        database.registerDataChangedNotifier(n2);
+
+        insertBasicTestModel();
+        assertTrue(n1.accumulateCalled);
+        assertTrue(n2.accumulateCalled);
+        assertTrue(n1.sendNotificationCalled);
+        assertTrue(n2.sendNotificationCalled);
+    }
+
+    public void testGlobalNotifiersNotifiedForAllTables() {
+        final Set<SqlTable<?>> calledForTables = new HashSet<SqlTable<?>>();
+        TestDataChangedNotifier globalNotifier = new TestDataChangedNotifier() {
+            @Override
+            protected boolean accumulateNotificationObjects(Set<TestDataChangedNotifier> accumulatorSet, SqlTable<?> table,
+                    SquidDatabase database, DBOperation operation, AbstractModel modelValues, long rowId) {
+                calledForTables.add(table);
+                return super.accumulateNotificationObjects(accumulatorSet, table, database, operation, modelValues, rowId);
+            }
+        };
+
+        database.registerDataChangedNotifier(globalNotifier);
+
+        insertBasicTestModel();
+        database.persist(new Employee().setName("Elmo"));
+
+        assertTrue(calledForTables.contains(TestModel.TABLE));
+        assertTrue(calledForTables.contains(Employee.TABLE));
+    }
+
+
+    public void testEnableAndDisableNotifications() {
+        TestDataChangedNotifier notifier = new TestDataChangedNotifier();
+        database.registerDataChangedNotifier(notifier);
+
+        database.beginTransaction();
+        try {
+            database.setDataChangedNotificationsEnabled(false);
+
+            insertBasicTestModel("Tech Sergeant", "Chen", System.currentTimeMillis() - 1);
+            database.setTransactionSuccessful();
+        } finally {
+            database.endTransaction();
+            assertFalse(notifier.accumulateCalled);
+            assertFalse(notifier.sendNotificationCalled);
+            database.setDataChangedNotificationsEnabled(true);
+            assertFalse(notifier.accumulateCalled);
+            assertFalse(notifier.sendNotificationCalled);
+        }
+
+        insertBasicTestModel();
+        assertTrue(notifier.accumulateCalled);
+        assertTrue(notifier.sendNotificationCalled);
+    }
+
+    public void testSimpleDataChangedNotifier() {
+        final AtomicInteger onDataChangedCalledCount = new AtomicInteger(0);
+        SimpleDataChangedNotifier notifier = new SimpleDataChangedNotifier() {
+            @Override
+            protected void onDataChanged() {
+                onDataChangedCalledCount.incrementAndGet();
+            }
+        };
+
+        database.registerDataChangedNotifier(notifier);
+        database.beginTransaction();
+        try {
+            insertBasicTestModel("Peter", "Quincy Taggart", System.currentTimeMillis() - 5);
+            insertBasicTestModel("Guy", "Fleegman", System.currentTimeMillis() - 4);
+            database.setTransactionSuccessful();
+        } finally {
+            database.endTransaction();
+        }
+        assertEquals(1, onDataChangedCalledCount.get());
+    }
+
+}

--- a/squidb-tests/src/com/yahoo/squidb/data/UriNotifierTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/UriNotifierTest.java
@@ -31,8 +31,7 @@ public class UriNotifierTest extends DatabaseTestCase {
         @Override
         protected boolean accumulateNotificationObjects(Set<Uri> accumulatorSet, SqlTable<?> table,
                 SquidDatabase database, DBOperation operation, AbstractModel modelValues, long rowId) {
-            accumulatorSet.add(TestModel.CONTENT_URI);
-            return true;
+            return accumulatorSet.add(TestModel.CONTENT_URI);
         }
     }
 
@@ -243,8 +242,7 @@ public class UriNotifierTest extends DatabaseTestCase {
             protected boolean accumulateNotificationObjects(Set<Uri> accumulatorSet, SqlTable<?> table,
                     SquidDatabase database, DBOperation operation, AbstractModel modelValues, long rowId) {
                 calledForTables.add(table);
-                accumulatorSet.add(Uri.parse("content://com.yahoo.squidb/"));
-                return true;
+                return accumulatorSet.add(Uri.parse("content://com.yahoo.squidb/"));
             }
         };
 
@@ -308,8 +306,7 @@ public class UriNotifierTest extends DatabaseTestCase {
                 if (rowId > 0) {
                     uri = uri.buildUpon().appendPath(Long.toString(rowId)).build();
                 }
-                accumulatorSet.add(uri);
-                return true;
+                return accumulatorSet.add(uri);
             }
         };
 

--- a/squidb/src/com/yahoo/squidb/data/DataChangedNotifier.java
+++ b/squidb/src/com/yahoo/squidb/data/DataChangedNotifier.java
@@ -129,14 +129,12 @@ public abstract class DataChangedNotifier<T> {
     // flushed/sent
     final void flushAccumulatedNotifications(SquidDatabase database, boolean shouldSendNotifications) {
         Set<T> accumulatedNotifications = notifyObjectAccumulator.get();
-        if (!enabled || !shouldSendNotifications) {
-            accumulatedNotifications.clear();
-            return;
+        if (enabled && shouldSendNotifications) {
+            for (T notifyObject : accumulatedNotifications) {
+                sendNotification(database, notifyObject);
+            }
         }
-
-        for (T notifyObject : accumulatedNotifications) {
-            sendNotification(database, notifyObject);
-        }
+        accumulatedNotifications.clear();
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/data/DataChangedNotifier.java
+++ b/squidb/src/com/yahoo/squidb/data/DataChangedNotifier.java
@@ -127,9 +127,9 @@ public abstract class DataChangedNotifier<T> {
 
     // Called by SquidDatabase when a transaction or statement has finished and any accumulated notifications should be
     // flushed/sent
-    final void flushAccumulatedNotifications(SquidDatabase database, boolean transactionSuccess) {
+    final void flushAccumulatedNotifications(SquidDatabase database, boolean shouldSendNotifications) {
         Set<T> accumulatedNotifications = notifyObjectAccumulator.get();
-        if (!enabled || !transactionSuccess) {
+        if (!enabled || !shouldSendNotifications) {
             accumulatedNotifications.clear();
             return;
         }

--- a/squidb/src/com/yahoo/squidb/data/DataChangedNotifier.java
+++ b/squidb/src/com/yahoo/squidb/data/DataChangedNotifier.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.data;
+
+import android.database.ContentObserver;
+import android.net.Uri;
+
+import com.yahoo.squidb.sql.SqlTable;
+import com.yahoo.squidb.sql.Table;
+import com.yahoo.squidb.sql.View;
+import com.yahoo.squidb.utility.SquidUtilities;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Subclasses of DataChangedNotifier can be registered with an instance of {@link SquidDatabase} to receive
+ * notifications whenever a table they are interested in is updated.
+ * <p>
+ * A DataChangedNotifier can be constructed to listen for database operations on specific instances of {@link SqlTable}
+ * (a {@link Table}, a {@link View}, etc.). If you want your DataChangedNotifier instance to be notified of all database
+ * operations regardless of table, use the no-argument constructor.
+ * <p>
+ * When an instance of DataChangedNotifier is registered with a SquidDatabase, the db will call {@link
+ * #onDataChanged(SqlTable, SquidDatabase, DBOperation, AbstractModel, long)} on the notifier whenever one of the
+ * notifier's relevant tables was modified.
+ * <p>
+ * Subclasses must override two abstract methods: {@link #accumulateNotificationObjects(Set, SqlTable, SquidDatabase,
+ * DBOperation, AbstractModel, long)} and {@link #sendNotification(SquidDatabase, Object)}. In
+ * accumulateNotificationObjects, the DataChangedNotifier subclass should add objects/metadata about that notification
+ * that needs to be sent for that data change when the statement transaction has completed successfully. When the
+ * statement or transaction completes successfully, sendNotification will be called for each object that was accumulated
+ * during the transaction. The subclass should define in this method how to actually send the notification.
+ *
+ * @param <T> the type of object/metadata to accumulate for sending notifications
+ * @see SquidDatabase#registerDataChangedNotifier(DataChangedNotifier)
+ * @see UriNotifier for an example of a DataChangedNotifier that can send ContentObserver notifications to Uris on data
+ * changes
+ */
+public abstract class DataChangedNotifier<T> {
+
+    /**
+     * Enumerates the possible database write operations
+     */
+    public enum DBOperation {
+        INSERT,
+        UPDATE,
+        DELETE
+    }
+
+    private final List<SqlTable<?>> tables = new ArrayList<SqlTable<?>>();
+    private boolean enabled = true;
+
+    // Using a ThreadLocal makes it easy to have one accumulator set per transaction, since
+    // transactions are also associated with the thread they run on
+    private ThreadLocal<Set<T>> notifyObjectAccumulator = new ThreadLocal<Set<T>>() {
+        protected Set<T> initialValue() {
+            return new HashSet<T>();
+        }
+    };
+
+    /**
+     * Construct a DataChangedNotifier that will be notified of changes to all tables
+     */
+    public DataChangedNotifier() {
+        // Valid for all tables
+    }
+
+    /**
+     * For constructing a DataChangedNotifier that will be notified of changes to the given tables
+     */
+    public DataChangedNotifier(SqlTable<?>... tables) {
+        SquidUtilities.addAll(this.tables, tables);
+    }
+
+    /**
+     * @return a list of {@link SqlTable SqlTables} that this DataChangedNotifier wants to receive notifications about.
+     * If this method returns an empty list, it will receive notifications about all database updates.
+     */
+    public List<SqlTable<?>> whichTables() {
+        return tables;
+    }
+
+    /**
+     * Set whether or not this DataChangedNotifier is enabled. When not enabled, no data changed notifications will be
+     * accumulated for any statement or transaction.
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    // Called by SquidDatabase for each data change
+    final boolean onDataChanged(SqlTable<?> table, SquidDatabase database, DBOperation operation,
+            AbstractModel modelValues, long rowId) {
+        if (!enabled) {
+            return false;
+        }
+
+        return accumulateNotificationObjects(notifyObjectAccumulator.get(), table, database, operation,
+                modelValues, rowId);
+    }
+
+    /**
+     * Subclasses override this abstract method to accumulate objects to notify at the end of a successful transaction.
+     * For example, in UriNotifier the objects to notify are Uris (so UriNotifier extends
+     * DataChangedNotifier&lt;Uri&gt;). If you want to just run arbitrary code after a data change, the object could be
+     * a Runnable.
+     *
+     * @param accumulatorSet add objects to be notified at the end of a successful transaction to this data set
+     * @param table the affected table.
+     * @param database the SquidDatabase instance this change occurred in
+     * @param operation the type of database write that occurred
+     * @param modelValues the model values that triggered this database update. This parameter may be null; the database
+     * will provide it when possible, but it is not always present. If you only need a row id, check the rowId
+     * parameter. This parameter will be null for delete operations, and will contain only the changed columns and
+     * their new values for updates.
+     * @param rowId the single row id that was updated, if applicable
+     * @return true if any objects were added to the accumulator set to be notified, false otherwise
+     */
+    protected abstract boolean accumulateNotificationObjects(Set<T> accumulatorSet, SqlTable<?> table,
+            SquidDatabase database, DBOperation operation, AbstractModel modelValues, long rowId);
+
+    // Called by SquidDatabase when a transaction or statement has finished and any accumulated notifications should be
+    // flushed/sent
+    final void flushAccumulatedNotifications(SquidDatabase database, boolean transactionSuccess) {
+        Set<T> accumulatedNotifications = notifyObjectAccumulator.get();
+        if (!enabled || !transactionSuccess) {
+            accumulatedNotifications.clear();
+            return;
+        }
+
+        for (T notifyObject : accumulatedNotifications) {
+            sendNotification(database, notifyObject);
+        }
+    }
+
+    /**
+     * Subclasses override this abstract method to define how to send a notification to the accumulated notifyObject.
+     * For example, in UriNotifier, the object is a Uri, so UriNotifier calls
+     * {@link android.content.ContentResolver#notifyChange(Uri, ContentObserver)} with the Uri. If the object were a
+     * Runnable, the caller could simply call {@link Runnable#run() run()}.
+     *
+     * @param database the SquidDatabase the change occurred in
+     * @param notifyObject the object to be used for sending a notification
+     */
+    protected abstract void sendNotification(SquidDatabase database, T notifyObject);
+
+}

--- a/squidb/src/com/yahoo/squidb/data/SimpleDataChangedNotifier.java
+++ b/squidb/src/com/yahoo/squidb/data/SimpleDataChangedNotifier.java
@@ -47,7 +47,7 @@ public abstract class SimpleDataChangedNotifier extends DataChangedNotifier<Simp
 
     /**
      * By overriding this method, subclasses of SimpleDataChangedNotifier can run arbitrary code after statements or
-     * transactions that modify the tables the notifier listens to have changed.
+     * transactions that modify the tables the notifier listens to.
      */
     protected abstract void onDataChanged();
 

--- a/squidb/src/com/yahoo/squidb/data/SimpleDataChangedNotifier.java
+++ b/squidb/src/com/yahoo/squidb/data/SimpleDataChangedNotifier.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.data;
+
+import com.yahoo.squidb.sql.SqlTable;
+
+import java.util.Set;
+
+/**
+ * SimpleDataChangedNotifier is a very basic implementation of {@link DataChangedNotifier}. Subclasses of
+ * SimpleDataChangedNotifier override a single, no-arg method: {@link #onDataChanged()}. This method will be called once
+ * at the end of any statement or transaction that modifies one or more of the tables that the notifier is listening to.
+ * In other words, it functions as a simple listener that can execute arbitrary code after any change to a table.
+ * <p>
+ * Note: Be wary of making further database changes from within onDataChanged()! It could trigger recursive data change
+ * notifications, which could eventually lead to a StackOverflowException or an infinite loop.
+ */
+public abstract class SimpleDataChangedNotifier extends DataChangedNotifier<SimpleDataChangedNotifier> {
+
+    /**
+     * Construct a SimpleDataChangedNotifier that will be notified of changes to all tables
+     */
+    public SimpleDataChangedNotifier() {
+        super();
+    }
+
+    /**
+     * Construct a SimpleDataChangedNotifier that will be notified of changes to the given tables
+     */
+    public SimpleDataChangedNotifier(SqlTable<?>... tables) {
+        super(tables);
+    }
+
+    @Override
+    protected final boolean accumulateNotificationObjects(Set<SimpleDataChangedNotifier> accumulatorSet, SqlTable<?> table,
+            SquidDatabase database, DBOperation operation, AbstractModel modelValues, long rowId) {
+        return accumulatorSet.add(this);
+    }
+
+    @Override
+    protected final void sendNotification(SquidDatabase database, SimpleDataChangedNotifier notifyObject) {
+        notifyObject.onDataChanged();
+    }
+
+    /**
+     * By overriding this method, subclasses of SimpleDataChangedNotifier can run arbitrary code after statements or
+     * transactions that modify the tables the notifier listens to have changed.
+     */
+    protected abstract void onDataChanged();
+
+}

--- a/squidb/src/com/yahoo/squidb/data/SimpleDataChangedNotifier.java
+++ b/squidb/src/com/yahoo/squidb/data/SimpleDataChangedNotifier.java
@@ -35,8 +35,8 @@ public abstract class SimpleDataChangedNotifier extends DataChangedNotifier<Simp
     }
 
     @Override
-    protected final boolean accumulateNotificationObjects(Set<SimpleDataChangedNotifier> accumulatorSet, SqlTable<?> table,
-            SquidDatabase database, DBOperation operation, AbstractModel modelValues, long rowId) {
+    protected final boolean accumulateNotificationObjects(Set<SimpleDataChangedNotifier> accumulatorSet,
+            SqlTable<?> table, SquidDatabase database, DBOperation operation, AbstractModel modelValues, long rowId) {
         return accumulatorSet.add(this);
     }
 

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -1742,7 +1742,7 @@ public abstract class SquidDatabase {
         }
     }
 
-    // --- Uri notification
+    // --- Data change notifications
 
     private final Object notifiersLock = new Object();
     private boolean dataChangedNotificationsEnabled = true;

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -766,7 +766,7 @@ public abstract class SquidDatabase {
         successState.endTransaction();
 
         if (!inTransaction()) {
-            flushAccumulatedUris(uriAccumulator.get(), successState.outerTransactionSuccess);
+            flushAccumulatedNotifications(successState.outerTransactionSuccess);
             successState.reset();
         }
     }
@@ -1429,7 +1429,7 @@ public abstract class SquidDatabase {
         Table table = getTable(modelClass);
         int rowsUpdated = deleteInternal(Delete.from(table).where(table.getIdProperty().eq(id)));
         if (rowsUpdated > 0) {
-            notifyForTable(UriNotifier.DBOperation.DELETE, null, table, id);
+            notifyForTable(DataChangedNotifier.DBOperation.DELETE, null, table, id);
         }
         return rowsUpdated > 0;
     }
@@ -1448,7 +1448,7 @@ public abstract class SquidDatabase {
         }
         int rowsUpdated = deleteInternal(delete);
         if (rowsUpdated > 0) {
-            notifyForTable(UriNotifier.DBOperation.DELETE, null, table, TableModel.NO_ID);
+            notifyForTable(DataChangedNotifier.DBOperation.DELETE, null, table, TableModel.NO_ID);
         }
         return rowsUpdated;
     }
@@ -1466,7 +1466,7 @@ public abstract class SquidDatabase {
     public int delete(Delete delete) {
         int result = deleteInternal(delete);
         if (result > 0) {
-            notifyForTable(UriNotifier.DBOperation.DELETE, null, delete.getTable(), TableModel.NO_ID);
+            notifyForTable(DataChangedNotifier.DBOperation.DELETE, null, delete.getTable(), TableModel.NO_ID);
         }
         return result;
     }
@@ -1513,7 +1513,7 @@ public abstract class SquidDatabase {
 
         int rowsUpdated = updateInternal(update);
         if (rowsUpdated > 0) {
-            notifyForTable(UriNotifier.DBOperation.UPDATE, template, table, TableModel.NO_ID);
+            notifyForTable(DataChangedNotifier.DBOperation.UPDATE, template, table, TableModel.NO_ID);
         }
         return rowsUpdated;
     }
@@ -1532,7 +1532,7 @@ public abstract class SquidDatabase {
     public int update(Update update) {
         int result = updateInternal(update);
         if (result > 0) {
-            notifyForTable(UriNotifier.DBOperation.UPDATE, null, update.getTable(), TableModel.NO_ID);
+            notifyForTable(DataChangedNotifier.DBOperation.UPDATE, null, update.getTable(), TableModel.NO_ID);
         }
         return result;
     }
@@ -1631,7 +1631,7 @@ public abstract class SquidDatabase {
         }
         boolean result = newRow > 0;
         if (result) {
-            notifyForTable(UriNotifier.DBOperation.INSERT, item, table, newRow);
+            notifyForTable(DataChangedNotifier.DBOperation.INSERT, item, table, newRow);
             item.setId(newRow);
             item.markSaved();
         }
@@ -1673,7 +1673,7 @@ public abstract class SquidDatabase {
         }
         boolean result = updateInternal(update) > 0;
         if (result) {
-            notifyForTable(UriNotifier.DBOperation.UPDATE, item, table, item.getId());
+            notifyForTable(DataChangedNotifier.DBOperation.UPDATE, item, table, item.getId());
             item.markSaved();
         }
         return result;
@@ -1693,7 +1693,7 @@ public abstract class SquidDatabase {
         long result = insertInternal(insert);
         if (result > TableModel.NO_ID) {
             int numInserted = insert.getNumRows();
-            notifyForTable(UriNotifier.DBOperation.INSERT, null, insert.getTable(),
+            notifyForTable(DataChangedNotifier.DBOperation.INSERT, null, insert.getTable(),
                     numInserted == 1 ? result : TableModel.NO_ID);
         }
         return result;
@@ -1744,38 +1744,41 @@ public abstract class SquidDatabase {
 
     // --- Uri notification
 
-    private final Object uriNotifiersLock = new Object();
-    private boolean uriNotificationsDisabled = false;
-    private List<UriNotifier> globalNotifiers = new ArrayList<UriNotifier>();
-    private Map<SqlTable<?>, List<UriNotifier>> tableNotifiers = new HashMap<SqlTable<?>, List<UriNotifier>>();
+    private final Object notifiersLock = new Object();
+    private boolean dataChangedNotificationsEnabled = true;
+    private List<DataChangedNotifier<?>> globalNotifiers = new ArrayList<DataChangedNotifier<?>>();
+    private Map<SqlTable<?>, List<DataChangedNotifier<?>>> tableNotifiers
+            = new HashMap<SqlTable<?>, List<DataChangedNotifier<?>>>();
 
     // Using a ThreadLocal makes it easy to have one accumulator set per transaction, since
     // transactions are also associated with the thread they run on
-    private ThreadLocal<Set<Uri>> uriAccumulator = new ThreadLocal<Set<Uri>>() {
-        protected Set<Uri> initialValue() {
-            return new HashSet<Uri>();
+    private ThreadLocal<Set<DataChangedNotifier<?>>> notifierAccumulator
+            = new ThreadLocal<Set<DataChangedNotifier<?>>>() {
+        protected Set<DataChangedNotifier<?>> initialValue() {
+            return new HashSet<DataChangedNotifier<?>>();
         }
     };
 
     /**
-     * Register a {@link UriNotifier} to listen for database changes. The UriNotifier object will be asked to return a
-     * Uri to notify whenever a table it is interested is modified.
+     * Register a {@link DataChangedNotifier} to listen for database changes. The DataChangedNotifier object will be
+     * notified whenever a table it is interested is modified, and can accumulate a set of notifications to send when
+     * the current transaction or statement completes successfully.
      *
-     * @param notifier the UriNotifier to register
+     * @param notifier the DataChangedNotifier to register
      */
-    public void registerUriNotifier(UriNotifier notifier) {
+    public void registerDataChangedNotifier(DataChangedNotifier<?> notifier) {
         if (notifier == null) {
             return;
         }
-        synchronized (uriNotifiersLock) {
+        synchronized (notifiersLock) {
             List<SqlTable<?>> tables = notifier.whichTables();
             if (tables == null || tables.isEmpty()) {
                 globalNotifiers.add(notifier);
             } else {
                 for (SqlTable<?> table : tables) {
-                    List<UriNotifier> notifiersForTable = tableNotifiers.get(table);
+                    List<DataChangedNotifier<?>> notifiersForTable = tableNotifiers.get(table);
                     if (notifiersForTable == null) {
-                        notifiersForTable = new ArrayList<UriNotifier>();
+                        notifiersForTable = new ArrayList<DataChangedNotifier<?>>();
                         tableNotifiers.put(table, notifiersForTable);
                     }
                     notifiersForTable.add(notifier);
@@ -1785,21 +1788,21 @@ public abstract class SquidDatabase {
     }
 
     /**
-     * Unregister a {@link UriNotifier} previously registered by {@link #registerUriNotifier(UriNotifier)}
+     * Unregister a {@link DataChangedNotifier} previously registered by {@link #registerDataChangedNotifier(DataChangedNotifier)}
      *
-     * @param notifier the UriNotifier to unregister
+     * @param notifier the DataChangedNotifier to unregister
      */
-    public void unregisterUriNotifier(UriNotifier notifier) {
+    public void unregisterDataChangedNotifier(DataChangedNotifier<?> notifier) {
         if (notifier == null) {
             return;
         }
-        synchronized (uriNotifiersLock) {
+        synchronized (notifiersLock) {
             List<SqlTable<?>> tables = notifier.whichTables();
             if (tables == null || tables.isEmpty()) {
                 globalNotifiers.remove(notifier);
             } else {
                 for (SqlTable<?> table : tables) {
-                    List<UriNotifier> notifiersForTable = tableNotifiers.get(table);
+                    List<DataChangedNotifier<?>> notifiersForTable = tableNotifiers.get(table);
                     if (notifiersForTable != null) {
                         notifiersForTable.remove(notifier);
                     }
@@ -1809,59 +1812,57 @@ public abstract class SquidDatabase {
     }
 
     /**
-     * Unregister all {@link UriNotifier}s previously registered by {@link #registerUriNotifier(UriNotifier)}
+     * Unregister all {@link DataChangedNotifier}s previously registered by {@link #registerDataChangedNotifierNotifier(DataChangedNotifier)}
      */
-    public void unregisterAllUriNotifiers() {
-        synchronized (uriNotifiersLock) {
+    public void unregisterAllDataChangedNotifiers() {
+        synchronized (notifiersLock) {
             globalNotifiers.clear();
             tableNotifiers.clear();
         }
     }
 
     /**
-     * Set a flag to disable Uri notifications. No Uris will be notified (or accumulated during transactions) after
-     * this method is called, until {@link #enableUriNotifications()} is called to re-enable notifications.
+     * Set a flag to enable or disable data change notifications. No {@link DataChangedNotifier}s will be notified
+     * (or accumulated during transactions) while the flag is set to false.
      */
-    public void disableUriNotifications() {
-        uriNotificationsDisabled = true;
+    public void setDataChangedNotificationsEnabled(boolean enabled) {
+        dataChangedNotificationsEnabled = enabled;
     }
 
-    /**
-     * Re-enables Uri notifications after a call to {@link #disableUriNotifications()}
-     */
-    public void enableUriNotifications() {
-        uriNotificationsDisabled = false;
-    }
-
-    private void notifyForTable(UriNotifier.DBOperation op, AbstractModel modelValues, SqlTable<?> table, long rowId) {
-        if (uriNotificationsDisabled) {
+    private void notifyForTable(DataChangedNotifier.DBOperation op, AbstractModel modelValues, SqlTable<?> table,
+            long rowId) {
+        if (!dataChangedNotificationsEnabled) {
             return;
         }
-        Set<Uri> accumulatorSet = uriAccumulator.get();
-        synchronized (uriNotifiersLock) {
-            accumulateUrisToNotify(globalNotifiers, accumulatorSet, op, modelValues, table, rowId);
-            accumulateUrisToNotify(tableNotifiers.get(table), accumulatorSet, op, modelValues, table, rowId);
+        synchronized (notifiersLock) {
+            onDataChanged(globalNotifiers, op, modelValues, table, rowId);
+            onDataChanged(tableNotifiers.get(table), op, modelValues, table, rowId);
         }
         if (!inTransaction()) {
-            flushAccumulatedUris(accumulatorSet, true);
+            flushAccumulatedNotifications(true);
         }
     }
 
-    private void accumulateUrisToNotify(List<UriNotifier> notifiers, Set<Uri> accumulatorSet,
-            UriNotifier.DBOperation op, AbstractModel modelValues, SqlTable<?> table, long rowId) {
+    private void onDataChanged(List<DataChangedNotifier<?>> notifiers, DataChangedNotifier.DBOperation op,
+            AbstractModel modelValues, SqlTable<?> table, long rowId) {
         if (notifiers != null) {
-            for (UriNotifier notifier : notifiers) {
-                notifier.addUrisToNotify(accumulatorSet, table, getName(), op, modelValues, rowId);
+            for (DataChangedNotifier<?> notifier : notifiers) {
+                if (notifier.onDataChanged(table, this, op, modelValues, rowId)) {
+                    notifierAccumulator.get().add(notifier);
+                }
             }
         }
     }
 
-    private void flushAccumulatedUris(Set<Uri> urisToNotify, boolean transactionSuccess) {
-        if (!urisToNotify.isEmpty()) {
-            if (transactionSuccess && !uriNotificationsDisabled) {
-                notifyChange(urisToNotify);
+    private void flushAccumulatedNotifications(boolean transactionSuccess) {
+        Set<DataChangedNotifier<?>> accumulatedNotifiers = notifierAccumulator.get();
+        if (!accumulatedNotifiers.isEmpty()) {
+            if (transactionSuccess && dataChangedNotificationsEnabled) {
+                for (DataChangedNotifier<?> notifier : accumulatedNotifiers) {
+                    notifier.flushAccumulatedNotifications(this, transactionSuccess);
+                }
             }
-            urisToNotify.clear();
+            accumulatedNotifiers.clear();
         }
     }
 }

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -1812,7 +1812,7 @@ public abstract class SquidDatabase {
     }
 
     /**
-     * Unregister all {@link DataChangedNotifier}s previously registered by {@link #registerDataChangedNotifierNotifier(DataChangedNotifier)}
+     * Unregister all {@link DataChangedNotifier}s previously registered by {@link #registerDataChangedNotifier(DataChangedNotifier)}
      */
     public void unregisterAllDataChangedNotifiers() {
         synchronized (notifiersLock) {

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -79,8 +79,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *
  * For this reason, these methods are protected rather than public. You can choose to expose them in your database
  * subclass if you wish, but we recommend that you instead use the typesafe, public, model-bases methods, such as
- * {@link #update(Criterion, TableModel)}, {@link #updateWithOnConflict(Criterion, TableModel, TableStatement.ConflictAlgorithm)},
- * {@link #delete(Class, long)}, and {@link #deleteWhere(Class, Criterion)}.
+ * {@link #update(Criterion, TableModel)}, {@link #updateWithOnConflict(Criterion, TableModel,
+ * TableStatement.ConflictAlgorithm)}, {@link #delete(Class, long)}, and {@link #deleteWhere(Class, Criterion)}.
  * <p>
  * As a convenience, when calling the {@link #query(Class, Query) query} and {@link #fetchByQuery(Class, Query)
  * fetchByQuery} methods, if the <code>query</code> argument does not have a FROM clause, the table or view to select
@@ -1788,7 +1788,8 @@ public abstract class SquidDatabase {
     }
 
     /**
-     * Unregister a {@link DataChangedNotifier} previously registered by {@link #registerDataChangedNotifier(DataChangedNotifier)}
+     * Unregister a {@link DataChangedNotifier} previously registered by
+     * {@link #registerDataChangedNotifier(DataChangedNotifier)}
      *
      * @param notifier the DataChangedNotifier to unregister
      */
@@ -1812,7 +1813,8 @@ public abstract class SquidDatabase {
     }
 
     /**
-     * Unregister all {@link DataChangedNotifier}s previously registered by {@link #registerDataChangedNotifier(DataChangedNotifier)}
+     * Unregister all {@link DataChangedNotifier}s previously registered by
+     * {@link #registerDataChangedNotifier(DataChangedNotifier)}
      */
     public void unregisterAllDataChangedNotifiers() {
         synchronized (notifiersLock) {

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -1857,10 +1857,8 @@ public abstract class SquidDatabase {
     private void flushAccumulatedNotifications(boolean transactionSuccess) {
         Set<DataChangedNotifier<?>> accumulatedNotifiers = notifierAccumulator.get();
         if (!accumulatedNotifiers.isEmpty()) {
-            if (transactionSuccess && dataChangedNotificationsEnabled) {
-                for (DataChangedNotifier<?> notifier : accumulatedNotifiers) {
-                    notifier.flushAccumulatedNotifications(this, transactionSuccess);
-                }
+            for (DataChangedNotifier<?> notifier : accumulatedNotifiers) {
+                notifier.flushAccumulatedNotifications(this, transactionSuccess && dataChangedNotificationsEnabled);
             }
             accumulatedNotifiers.clear();
         }

--- a/squidb/src/com/yahoo/squidb/data/UriNotifier.java
+++ b/squidb/src/com/yahoo/squidb/data/UriNotifier.java
@@ -23,10 +23,10 @@ import java.util.Set;
  * automatically). If you want your UriNotifier instance to be notified of all database operations regardless of table,
  * use the no-argument constructor.
  * <p>
- * When an instance of UriNotifier is registered with a SquidDatabase, the db will call {@link #addUrisToNotify(Set,
- * SqlTable, String, DBOperation, AbstractModel, long) addUrisToNotify} on the notifier whenever one of the
- * notifier's relevant tables was modified. Subclasses should override this method to construct a Uri to notify based
- * on the parameters passed to the method.
+ * When an instance of UriNotifier is registered with a SquidDatabase, the db will call {@link
+ * #accumulateNotificationObjects(Set, SqlTable, SquidDatabase, DBOperation, AbstractModel, long)}  on the
+ * notifier whenever one of the notifier's relevant tables was modified. Subclasses should override this method to
+ * construct a Uri to notify based on the parameters passed to the method.
  *
  * @see DataChangedNotifier
  * @see SquidDatabase#registerDataChangedNotifier(DataChangedNotifier)
@@ -41,7 +41,7 @@ public abstract class UriNotifier extends DataChangedNotifier<Uri> {
     }
 
     /**
-     * For constructing a UriNotifier that will be notified of changes to the given tables
+     * Construct a UriNotifier that will be notified of changes to the given tables
      */
     public UriNotifier(SqlTable<?>... tables) {
         super(tables);
@@ -58,12 +58,13 @@ public abstract class UriNotifier extends DataChangedNotifier<Uri> {
      * Most UriNotifiers will probably not need all these parameters. For example:
      *
      * <pre>
-     * public void addUrisToNotify(Set&lt;Uri&gt; uris, SqlTable&lt;?&gt; table, String databaseName, DBOperation operation,
-     *     AbstractModel modelValues, long rowId) {
+     * protected boolean accumulateNotificationObjects(Set&lt;Uri&gtl accumulatorSet, SqlTable&lt;?&gt; table,
+     *     SquidDatabase database, DBOperation operation, AbstractModel modelValues, long rowId) {
      *     // Notifies some constant Uri for any update on the students table
      *     if (Student.TABLE.equals(table)) {
-     *         uris.add(Student.CONTENT_URI);
+     *         return uris.add(Student.CONTENT_URI);
      *     }
+     *     return false;
      * }
      * </pre>
      *

--- a/squidb/src/com/yahoo/squidb/data/UriNotifier.java
+++ b/squidb/src/com/yahoo/squidb/data/UriNotifier.java
@@ -24,7 +24,7 @@ import java.util.Set;
  * use the no-argument constructor.
  * <p>
  * When an instance of UriNotifier is registered with a SquidDatabase, the db will call {@link
- * #accumulateNotificationObjects(Set, SqlTable, SquidDatabase, DBOperation, AbstractModel, long)}  on the
+ * #accumulateNotificationObjects(Set, SqlTable, SquidDatabase, DBOperation, AbstractModel, long)} on the
  * notifier whenever one of the notifier's relevant tables was modified. Subclasses should override this method to
  * construct a Uri to notify based on the parameters passed to the method.
  *
@@ -58,7 +58,7 @@ public abstract class UriNotifier extends DataChangedNotifier<Uri> {
      * Most UriNotifiers will probably not need all these parameters. For example:
      *
      * <pre>
-     * protected boolean accumulateNotificationObjects(Set&lt;Uri&gtl accumulatorSet, SqlTable&lt;?&gt; table,
+     * protected boolean accumulateNotificationObjects(Set&lt;Uri&gt; accumulatorSet, SqlTable&lt;?&gt; table,
      *     SquidDatabase database, DBOperation operation, AbstractModel modelValues, long rowId) {
      *     // Notifies some constant Uri for any update on the students table
      *     if (Student.TABLE.equals(table)) {

--- a/squidb/src/com/yahoo/squidb/sql/Criterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/Criterion.java
@@ -147,7 +147,8 @@ public abstract class Criterion extends CompilableWithArguments {
      * {@link SqlBuilder#addValueToSql(Object, boolean)} to handle this properly.
      *
      * @param builder The {@link SqlBuilder} for building the SQL statement
-     * @param forSqlValidation forSqlValidation true if this statement is being compiled to validate against malicious SQL
+     * @param forSqlValidation forSqlValidation true if this statement is being compiled to validate against malicious
+     * SQL
      */
     protected abstract void populate(SqlBuilder builder, boolean forSqlValidation);
 
@@ -155,7 +156,8 @@ public abstract class Criterion extends CompilableWithArguments {
      * Append a string representation of this Criterion
      *
      * @param builder The {@link SqlBuilder} for building the SQL statement
-     * @param forSqlValidation forSqlValidation true if this statement is being compiled to validate against malicious SQL
+     * @param forSqlValidation forSqlValidation true if this statement is being compiled to validate against malicious
+     * SQL
      */
     @Override
     void appendToSqlBuilder(SqlBuilder builder, boolean forSqlValidation) {

--- a/squidb/src/com/yahoo/squidb/sql/SqlBuilder.java
+++ b/squidb/src/com/yahoo/squidb/sql/SqlBuilder.java
@@ -60,7 +60,8 @@ public final class SqlBuilder {
      * syntactic string like SELECT), you can access the {@link #sql} StringBuilder directly.
      *
      * @param value The value to be appended
-     * @param forSqlValidation forSqlValidation true if this statement is being compiled to validate against malicious SQL
+     * @param forSqlValidation forSqlValidation true if this statement is being compiled to validate against malicious
+     * SQL
      */
     public void addValueToSql(Object value, boolean forSqlValidation) {
         if (value instanceof DBObject<?>) {


### PR DESCRIPTION
This PR abstracts out the concepts from our UriNotifier to introduce a fully generic/customizable data changed notification mechanism. The abstract class DataChangedNotifier can be overridden to accumulate an arbitrary set of objects to notify based on data changes during transactions and send notifications to those objects at the end of a successful transaction. UriNotifier then becomes a specific instance of DataChangedNotifier--the objects accumulated are the Uris themselves, and sendNotification is implemented by calling ContentResolver.notifyChange.

SimpleDataChangedNotifier is also introduced as a very simple implementation of a DataChangedNotifier. It simply allows running arbitrary code at the end of a successful transaction if the tables it listens to have changed by overriding a single method.

API changes:
* SquidDatabase.registerUriNotifier and related methods have been renamed to things like registerDataChangedNotifier, etc.
* UriNotifier.addUrisToNotify has been renamed to accumulateNotificationObjects, since it is now a subclass of the generic DataChangedNotifier class.