### PR TITLE
Remove Criterion.all and Criterion.none [2.0]

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -7,7 +7,6 @@ package com.yahoo.squidb.data;
 
 import android.content.ContentValues;
 
-import com.yahoo.squidb.sql.Criterion;
 import com.yahoo.squidb.sql.Property;
 import com.yahoo.squidb.test.DatabaseTestCase;
 import com.yahoo.squidb.test.TestModel;
@@ -56,7 +55,7 @@ public class ModelTest extends DatabaseTestCase {
     public void testCrudMethods() {
         // insert
         TestModel model = insertBasicTestModel("Sam", "Bosley", testDate);
-        assertEquals(1, database.count(TestModel.class, Criterion.all));
+        assertEquals(1, database.countAll(TestModel.class));
 
         // query
         final long id = model.getId();
@@ -66,11 +65,11 @@ public class ModelTest extends DatabaseTestCase {
         // update
         model.setFirstName("Jack").setLastName("Sparrow").setBirthday(System.currentTimeMillis());
         assertTrue(database.saveExisting(model));
-        assertEquals(1, database.count(TestModel.class, Criterion.all));
+        assertEquals(1, database.countAll(TestModel.class));
 
         // delete
         assertTrue(database.delete(TestModel.class, id));
-        assertEquals(0, database.count(TestModel.class, Criterion.all));
+        assertEquals(0, database.countAll(TestModel.class));
     }
 
     public void testCrudMethodsWithNonDefaultPrimaryKey() {
@@ -85,11 +84,11 @@ public class ModelTest extends DatabaseTestCase {
         database.persist(thing);
         fetched = database.fetch(Thing.class, thing.getId(), Thing.PROPERTIES);
         assertEquals("new foo", fetched.getFoo());
-        assertEquals(1, database.count(Thing.class, Criterion.all));
+        assertEquals(1, database.countAll(Thing.class));
 
         // delete
         assertTrue(database.delete(Thing.class, thing.getId()));
-        assertEquals(0, database.count(Thing.class, Criterion.all));
+        assertEquals(0, database.countAll(Thing.class));
     }
 
     public void testDeprecatedPropertiesNotIncluded() {

--- a/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
@@ -11,7 +11,6 @@ import android.database.sqlite.SQLiteConstraintException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 
-import com.yahoo.squidb.sql.Criterion;
 import com.yahoo.squidb.sql.Property;
 import com.yahoo.squidb.sql.Property.StringProperty;
 import com.yahoo.squidb.sql.Query;
@@ -47,7 +46,7 @@ public class SquidDatabaseTest extends DatabaseTestCase {
         Cursor cursor = null;
         try {
             // Sanity check that there is only one row in the table
-            assertEquals(1, badDatabase.count(TestModel.class, Criterion.all));
+            assertEquals(1, badDatabase.countAll(TestModel.class));
 
             // Test that raw query binds arguments correctly--if the argument
             // is bound as a String, the result will be empty
@@ -131,14 +130,14 @@ public class SquidDatabaseTest extends DatabaseTestCase {
         badDatabase.persist(new Employee().setName("Alice"));
         badDatabase.persist(new Employee().setName("Bob"));
         badDatabase.persist(new Employee().setName("Cindy"));
-        assertEquals(3, badDatabase.count(Employee.class, Criterion.all));
+        assertEquals(3, badDatabase.countAll(Employee.class));
 
         testMigrationFailureCalled(upgrade, false, true);
 
         // verify the db was recreated with the appropriate version and no previous data
         SQLiteDatabase db = badDatabase.getDatabase();
         assertEquals(badDatabase.getVersion(), db.getVersion());
-        assertEquals(0, badDatabase.count(Employee.class, Criterion.all));
+        assertEquals(0, badDatabase.countAll(Employee.class));
     }
 
     public void testAcquireExclusiveLockFailsWhenInTransaction() {
@@ -297,7 +296,8 @@ public class SquidDatabaseTest extends DatabaseTestCase {
         database.persist(model);
         result.close();
 
-        result = database.query(TestModel.class, Query.select(TestModel.PROPERTIES).where(TestModel.IS_HAPPY.isFalse()));
+        result = database
+                .query(TestModel.class, Query.select(TestModel.PROPERTIES).where(TestModel.IS_HAPPY.isFalse()));
         assertEquals(1, result.getCount());
         result.moveToFirst();
         model = new TestModel(result);
@@ -378,6 +378,6 @@ public class SquidDatabaseTest extends DatabaseTestCase {
 
         assertEquals(modelId, model.getId());
         assertNotNull(database.fetch(TestModel.class, model.getId()));
-        assertEquals(1, database.count(TestModel.class, Criterion.all));
+        assertEquals(1, database.countAll(TestModel.class));
     }
 }

--- a/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
@@ -285,8 +285,8 @@ public class SquidDatabaseTest extends DatabaseTestCase {
     public void testQueriesWithBooleanPropertiesWork() {
         insertBasicTestModel();
 
-        SquidCursor<TestModel> result = database
-                .query(TestModel.class, Query.select(TestModel.PROPERTIES).where(TestModel.IS_HAPPY.isTrue()));
+        SquidCursor<TestModel> result = database.query(TestModel.class,
+                Query.select(TestModel.PROPERTIES).where(TestModel.IS_HAPPY.isTrue()));
         assertEquals(1, result.getCount());
         result.moveToFirst();
         TestModel model = new TestModel(result);
@@ -296,8 +296,8 @@ public class SquidDatabaseTest extends DatabaseTestCase {
         database.persist(model);
         result.close();
 
-        result = database
-                .query(TestModel.class, Query.select(TestModel.PROPERTIES).where(TestModel.IS_HAPPY.isFalse()));
+        result = database.query(TestModel.class,
+                Query.select(TestModel.PROPERTIES).where(TestModel.IS_HAPPY.isFalse()));
         assertEquals(1, result.getCount());
         result.moveToFirst();
         model = new TestModel(result);
@@ -314,8 +314,7 @@ public class SquidDatabaseTest extends DatabaseTestCase {
         boolean result = database.persistWithOnConflict(conflict, TableStatement.ConflictAlgorithm.IGNORE);
         assertFalse(result);
         TestModel shouldntExist = database.fetchByCriterion(TestModel.class,
-                TestModel.FIRST_NAME.eq("Dave").and(TestModel.LAST_NAME.eq("Bosley")),
-                TestModel.PROPERTIES);
+                TestModel.FIRST_NAME.eq("Dave").and(TestModel.LAST_NAME.eq("Bosley")), TestModel.PROPERTIES);
         assertNull(shouldntExist);
         SQLiteConstraintException expected = null;
         try {

--- a/squidb-tests/src/com/yahoo/squidb/data/VirtualModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/VirtualModelTest.java
@@ -5,7 +5,6 @@
  */
 package com.yahoo.squidb.data;
 
-import com.yahoo.squidb.sql.Criterion;
 import com.yahoo.squidb.test.DatabaseTestCase;
 import com.yahoo.squidb.test.TestVirtualModel;
 
@@ -17,7 +16,7 @@ public class VirtualModelTest extends DatabaseTestCase {
                 .setTitle("Charlie")
                 .setBody("Charlie and the Chocolate Factory");
         assertTrue(database.createNew(model));
-        assertEquals(1, database.count(TestVirtualModel.class, Criterion.all));
+        assertEquals(1, database.countAll(TestVirtualModel.class));
 
         // query
         final long id = model.getId();
@@ -27,18 +26,18 @@ public class VirtualModelTest extends DatabaseTestCase {
         // update
         model.setTitle("Charlie Brown").setBody("It's the Easter Beagle, Charlie Brown");
         assertTrue(database.saveExisting(model));
-        assertEquals(1, database.count(TestVirtualModel.class, Criterion.all));
+        assertEquals(1, database.countAll(TestVirtualModel.class));
         assertEquals(1, database.count(TestVirtualModel.class, TestVirtualModel.TITLE.eq("Charlie Brown")));
 
         // update using setId on a template
         TestVirtualModel model2 = new TestVirtualModel().setTitle("Charlie Brown 2").setId(model.getId());
         assertTrue(database.saveExisting(model2));
-        assertEquals(1, database.count(TestVirtualModel.class, Criterion.all));
+        assertEquals(1, database.countAll(TestVirtualModel.class));
         assertEquals(1, database.count(TestVirtualModel.class, TestVirtualModel.TITLE.eq("Charlie Brown 2")));
 
         // delete
         assertTrue(database.delete(TestVirtualModel.class, id));
-        assertEquals(0, database.count(TestVirtualModel.class, Criterion.all));
+        assertEquals(0, database.countAll(TestVirtualModel.class));
     }
 
     public void testNonStringPropertyInVirtualTableModel() {

--- a/squidb-tests/src/com/yahoo/squidb/sql/AttachDetachTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/AttachDetachTest.java
@@ -35,7 +35,7 @@ public class AttachDetachTest extends DatabaseTestCase {
         database.persist(virtualModel);
 
         database2.clear();
-        assertEquals(0, database2.count(TestModel.class, Criterion.all));
+        assertEquals(0, database2.countAll(TestModel.class));
     }
 
     public void testAttachDetach() {
@@ -177,8 +177,8 @@ public class AttachDetachTest extends DatabaseTestCase {
         if (threadFailed.get() != null) {
             throw threadFailed.get();
         }
-        assertEquals(4, database.count(TestModel.class, Criterion.all));
-        assertEquals(3 + (transactionBeforeAttach ? 1 : 0), database2.count(TestModel.class, Criterion.all));
+        assertEquals(4, database.countAll(TestModel.class));
+        assertEquals(3 + (transactionBeforeAttach ? 1 : 0), database2.countAll(TestModel.class));
     }
 
     /*
@@ -230,7 +230,7 @@ public class AttachDetachTest extends DatabaseTestCase {
         if (threadFailed.get() != null) {
             throw threadFailed.get();
         }
-        assertEquals(4, database2.count(TestModel.class, Criterion.all));
+        assertEquals(4, database2.countAll(TestModel.class));
     }
 
 }

--- a/squidb-tests/src/com/yahoo/squidb/sql/CriterionTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/CriterionTest.java
@@ -52,4 +52,34 @@ public class CriterionTest extends SquidTestCase {
         assertNull(Criterion.fromRawSelection(null, null));
         assertNull(Criterion.fromRawSelection("", null));
     }
+
+    public void testNullCriterionsInBadPlacesThrowExceptions() {
+        testThrowsException(new Runnable() {
+            @Override
+            public void run() {
+                Criterion.and(null, TestModel.ID.eq(1));
+            }
+        }, IllegalArgumentException.class);
+
+        testThrowsException(new Runnable() {
+            @Override
+            public void run() {
+                Criterion.or(null, TestModel.ID.eq(1));
+            }
+        }, IllegalArgumentException.class);
+
+        testThrowsException(new Runnable() {
+            @Override
+            public void run() {
+                Function.caseWhen(null, 1);
+            }
+        }, IllegalArgumentException.class);
+
+        testThrowsException(new Runnable() {
+            @Override
+            public void run() {
+                Criterion.not(null);
+            }
+        }, IllegalArgumentException.class);
+    }
 }

--- a/squidb-tests/src/com/yahoo/squidb/sql/CriterionTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/CriterionTest.java
@@ -20,7 +20,6 @@ public class CriterionTest extends SquidTestCase {
         assertNegationEqualsTheOther(TestModel.FIRST_NAME.in(Collections.EMPTY_SET),
                 Criterion.not(TestModel.FIRST_NAME.in(Collections.EMPTY_SET)));
         assertNegationEqualsTheOther(TestModel.FIRST_NAME.isNull(), TestModel.FIRST_NAME.isNotNull());
-        assertNegationEqualsTheOther(Criterion.all, Criterion.none);
     }
 
     private void assertNegationEqualsTheOther(Criterion c1, Criterion c2) {
@@ -49,8 +48,8 @@ public class CriterionTest extends SquidTestCase {
         assertEquals(Criterion.or(c1, Criterion.and(c2, c3)), c1.or(c2.and(c3)));
     }
 
-    public void testEmptyRawSelectionIsEquivalentToAll() {
-        assertEquals(Criterion.all, Criterion.fromRawSelection(null, null));
-        assertEquals(Criterion.all, Criterion.fromRawSelection("", null));
+    public void testEmptyRawSelectionReturnsNull() {
+        assertNull(Criterion.fromRawSelection(null, null));
+        assertNull(Criterion.fromRawSelection("", null));
     }
 }

--- a/squidb-tests/src/com/yahoo/squidb/sql/DeleteTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/DeleteTest.java
@@ -61,7 +61,7 @@ public class DeleteTest extends DatabaseTestCase {
 
         assertEquals(1, database.delete(delete));
 
-        int numRows = database.count(TestModel.class, Criterion.all);
+        int numRows = database.countAll(TestModel.class);
         assertEquals(3, numRows);
 
         TestModel shouldNotBeFound = database.fetchByCriterion(TestModel.class, criterion, TestModel.PROPERTIES);
@@ -70,7 +70,7 @@ public class DeleteTest extends DatabaseTestCase {
 
     public void testDeleteAll() {
         // check preconditions
-        int numRows = database.count(TestModel.class, Criterion.all);
+        int numRows = database.countAll(TestModel.class);
         assertTrue(numRows > 0);
 
         // delete from testModels
@@ -80,7 +80,7 @@ public class DeleteTest extends DatabaseTestCase {
 
         assertEquals(numRows, database.delete(delete));
 
-        numRows = database.count(TestModel.class, Criterion.all);
+        numRows = database.countAll(TestModel.class);
         assertEquals(0, numRows);
     }
 }

--- a/squidb-tests/src/com/yahoo/squidb/sql/InsertTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/InsertTest.java
@@ -130,9 +130,9 @@ public class InsertTest extends DatabaseTestCase {
 
         verifyCompiledSqlArgs(compiled, 1, pi);
 
-        int testModelsBeforeInsert = database.count(TestModel.class, Criterion.all);
+        int testModelsBeforeInsert = database.countAll(TestModel.class);
         assertEquals(3, database.insert(insert));
-        int testModelsAfterInsert = database.count(TestModel.class, Criterion.all);
+        int testModelsAfterInsert = database.countAll(TestModel.class);
         assertEquals(testModelsBeforeInsert + numThingsMatching, testModelsAfterInsert);
     }
 
@@ -143,9 +143,9 @@ public class InsertTest extends DatabaseTestCase {
 
         verifyCompiledSqlArgs(compiled, 0);
 
-        int rowsBeforeInsert = database.count(Thing.class, Criterion.all);
+        int rowsBeforeInsert = database.countAll(Thing.class);
         assertEquals(3, database.insert(insert));
-        int rowsAfterInsert = database.count(Thing.class, Criterion.all);
+        int rowsAfterInsert = database.countAll(Thing.class);
 
         assertEquals(rowsBeforeInsert + 1, rowsAfterInsert);
 
@@ -190,9 +190,9 @@ public class InsertTest extends DatabaseTestCase {
 
         verifyCompiledSqlArgs(compiled, 4, fname, lname, isHappy, luckyNumber);
 
-        int rowsBeforeInsert = database.count(Thing.class, Criterion.all);
+        int rowsBeforeInsert = database.countAll(Thing.class);
         assertEquals(-1, database.insert(insert)); // Expect conflict
-        int rowsAfterInsert = database.count(Thing.class, Criterion.all);
+        int rowsAfterInsert = database.countAll(Thing.class);
 
         assertEquals(rowsBeforeInsert, rowsAfterInsert);
 
@@ -225,9 +225,9 @@ public class InsertTest extends DatabaseTestCase {
 
         verifyCompiledSqlArgs(compiled, 4, fname, lname, isHappy, luckyNumber);
 
-        int rowsBeforeInsert = database.count(Thing.class, Criterion.all);
+        int rowsBeforeInsert = database.countAll(Thing.class);
         assertEquals(rowsBeforeInsert, database.insert(insert)); // Expect replace
-        int rowsAfterInsert = database.count(Thing.class, Criterion.all);
+        int rowsAfterInsert = database.countAll(Thing.class);
 
         assertEquals(rowsBeforeInsert, rowsAfterInsert);
 

--- a/squidb-tests/src/com/yahoo/squidb/sql/QueryTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/QueryTest.java
@@ -454,7 +454,7 @@ public class QueryTest extends DatabaseTestCase {
             database.endTransaction();
         }
         assertTrue(rowIds.size() > SqlStatement.MAX_VARIABLE_NUMBER);
-        assertTrue(database.count(TestModel.class, Criterion.all) > SqlStatement.MAX_VARIABLE_NUMBER);
+        assertTrue(database.countAll(TestModel.class) > SqlStatement.MAX_VARIABLE_NUMBER);
 
         Query query = Query.select(TestModel.ID).where(TestModel.ID.in(rowIds));
         testMaxSqlArgRowIds(query, rowIds.size());
@@ -585,7 +585,7 @@ public class QueryTest extends DatabaseTestCase {
         database.persist(modelOne);
         database.persist(modelTwo);
         database.persist(modelThree);
-        assertEquals(3, database.count(TestModel.class, Criterion.all));
+        assertEquals(3, database.countAll(TestModel.class));
 
         database.deleteWhere(TestModel.class,
                 TestModel.ID.lt(Query.select(Function.max(TestModel.ID)).from(TestModel.TABLE)));
@@ -727,7 +727,7 @@ public class QueryTest extends DatabaseTestCase {
         Query q = Query.select().where(Employee.NAME.eq("'Sam'); drop table " + Employee.TABLE.getName() + ";"));
         SquidCursor<Employee> cursor = database.query(Employee.class, q);
         try {
-            assertFalse(database.count(Employee.class, Criterion.all) == 0);
+            assertFalse(database.countAll(Employee.class) == 0);
         } finally {
             cursor.close();
         }
@@ -900,7 +900,7 @@ public class QueryTest extends DatabaseTestCase {
 
         SubqueryTable subqueryTable = subquery.as("t1");
         SubqueryTable joinTable = joinSubquery.as("t2");
-        Query query = Query.select().from(subqueryTable).innerJoin(joinTable, Criterion.all)
+        Query query = Query.select().from(subqueryTable).innerJoin(joinTable, (Criterion[]) null)
                 .union(compoundSubquery);
 
         final int queryLength = query.compile().sql.length();
@@ -941,7 +941,7 @@ public class QueryTest extends DatabaseTestCase {
                 try {
                     blockThread.acquire();
 
-                    Query query2 = Query.select().from(subqueryTable).where(Criterion.all);
+                    Query query2 = Query.select().from(subqueryTable);
                     query2.requestValidation();
 
                     SquidCursor<Thing> cursor = database.query(Thing.class, query2);
@@ -975,7 +975,7 @@ public class QueryTest extends DatabaseTestCase {
         Query testQuery = baseTestQuery.from(subquery.as("t1"));
         assertTrue(testQuery.compile().needsValidation);
         assertTrue(testQuery.sqlForValidation().contains("WHERE ((?))"));
-        testQuery = baseTestQuery.innerJoin(subquery.as("t2"), Criterion.all);
+        testQuery = baseTestQuery.innerJoin(subquery.as("t2"), (Criterion[]) null);
         assertTrue(testQuery.compile().needsValidation);
         assertTrue(testQuery.sqlForValidation().contains("WHERE ((?))"));
         testQuery = baseTestQuery.union(subquery);
@@ -1040,7 +1040,7 @@ public class QueryTest extends DatabaseTestCase {
 
         SquidCursor<Employee> cursor = database.query(Employee.class, baseQuery);
         try {
-            assertEquals(database.count(Employee.class, Criterion.all), cursor.getCount());
+            assertEquals(database.countAll(Employee.class), cursor.getCount());
             while (cursor.moveToNext()) {
                 assertEquals(cursor.get(Employee.ID) + 1, cursor.get(idPlus1).longValue());
             }

--- a/squidb-tests/src/com/yahoo/squidb/sql/UpdateTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/UpdateTest.java
@@ -76,7 +76,7 @@ public class UpdateTest extends DatabaseTestCase {
         final int newLuckyNumber = 99;
 
         // check preconditions
-        int numRows = database.count(TestModel.class, Criterion.all);
+        int numRows = database.countAll(TestModel.class);
         assertTrue(numRows > 0);
         int shouldBeZero = database.count(TestModel.class, TestModel.LUCKY_NUMBER.eq(newLuckyNumber));
         assertEquals(0, shouldBeZero);

--- a/squidb/src/com/yahoo/squidb/sql/ConjunctionCriterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/ConjunctionCriterion.java
@@ -12,6 +12,13 @@ class ConjunctionCriterion extends Criterion {
 
     ConjunctionCriterion(Operator operator, Criterion criterion, Criterion... additionalCriterions) {
         super(operator);
+        if (criterion == null) {
+            throw new IllegalArgumentException("Base criterion of a ConjunctionCriterion cannot be null");
+        }
+        if (additionalCriterions == null) {
+            throw new IllegalArgumentException(
+                    "Can't pass a null array for additional criterions in a ConjunctionCriterion");
+        }
         this.baseCriterion = criterion;
         this.additionalCriterions = additionalCriterions;
     }
@@ -31,8 +38,10 @@ class ConjunctionCriterion extends Criterion {
     protected void populate(SqlBuilder builder, boolean forSqlValidation) {
         baseCriterion.appendToSqlBuilder(builder, forSqlValidation);
         for (Criterion c : additionalCriterions) {
-            builder.sql.append(operator);
-            c.appendToSqlBuilder(builder, forSqlValidation);
+            if (c != null) {
+                builder.sql.append(operator);
+                c.appendToSqlBuilder(builder, forSqlValidation);
+            }
         }
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/Criterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/Criterion.java
@@ -84,6 +84,9 @@ public abstract class Criterion extends CompilableWithArguments {
         return new Criterion(null) {
             @Override
             protected void populate(SqlBuilder builder, boolean forSqlValidation) {
+                if (forSqlValidation) {
+                    builder.sql.append("(");
+                }
                 builder.sql.append(selection);
                 if (selectionArgs != null && selectionArgs.length > 0) {
                     if (builder.args == null) {
@@ -91,6 +94,9 @@ public abstract class Criterion extends CompilableWithArguments {
                                 + "it cannot converted to raw SQL without bound arguments.");
                     }
                     Collections.addAll(builder.args, selectionArgs);
+                }
+                if (forSqlValidation) {
+                    builder.sql.append(")");
                 }
             }
         };

--- a/squidb/src/com/yahoo/squidb/sql/Criterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/Criterion.java
@@ -39,36 +39,6 @@ public abstract class Criterion extends CompilableWithArguments {
     }
 
     /**
-     * All rows match this criterion
-     */
-    public static final Criterion all = new Criterion(null) {
-        @Override
-        protected void populate(SqlBuilder builder, boolean forSqlValidation) {
-            builder.sql.append(1);
-        }
-
-        @Override
-        public Criterion negate() {
-            return none;
-        }
-    };
-
-    /**
-     * No rows match this criterion
-     */
-    public static final Criterion none = new Criterion(null) {
-        @Override
-        protected void populate(SqlBuilder builder, boolean forSqlValidation) {
-            builder.sql.append(0);
-        }
-
-        @Override
-        public Criterion negate() {
-            return all;
-        }
-    };
-
-    /**
      * @return a {@link Criterion} that combines the given criterions with AND
      */
     public static Criterion and(final Criterion criterion, final Criterion... criterions) {
@@ -104,11 +74,12 @@ public abstract class Criterion extends CompilableWithArguments {
     }
 
     /**
-     * @return a {@link Criterion} that evaluates the raw selection and selection args
+     * @return a {@link Criterion} that evaluates the raw selection and selection args. If the selection string is
+     * empty, this will return null.
      */
     public static Criterion fromRawSelection(final String selection, final String[] selectionArgs) {
         if (TextUtils.isEmpty(selection)) {
-            return Criterion.all;
+            return null;
         }
         return new Criterion(null) {
             @Override
@@ -117,7 +88,7 @@ public abstract class Criterion extends CompilableWithArguments {
                 if (selectionArgs != null && selectionArgs.length > 0) {
                     if (builder.args == null) {
                         throw new UnsupportedOperationException("Raw selection cannot be used in this context--"
-                            + "it cannot converted to raw SQL without bound arguments.");
+                                + "it cannot converted to raw SQL without bound arguments.");
                     }
                     Collections.addAll(builder.args, selectionArgs);
                 }

--- a/squidb/src/com/yahoo/squidb/sql/Criterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/Criterion.java
@@ -41,14 +41,14 @@ public abstract class Criterion extends CompilableWithArguments {
     /**
      * @return a {@link Criterion} that combines the given criterions with AND
      */
-    public static Criterion and(final Criterion criterion, final Criterion... criterions) {
+    public static Criterion and(Criterion criterion, Criterion... criterions) {
         return new ConjunctionCriterion(Operator.and, criterion, criterions);
     }
 
     /**
      * @return a {@link Criterion} that combines the given criterions with OR
      */
-    public static Criterion or(final Criterion criterion, final Criterion... criterions) {
+    public static Criterion or(Criterion criterion, Criterion... criterions) {
         return new ConjunctionCriterion(Operator.or, criterion, criterions);
     }
 
@@ -148,18 +148,24 @@ public abstract class Criterion extends CompilableWithArguments {
     }
 
     /**
-     * @param criterion another criterion to be appended with AND
+     * @param criterion another criterion to be appended with AND. If null, this Criterion will be returned unmodified.
      * @return a criterion equivalent to (this AND criterion)
      */
     public Criterion and(Criterion criterion) {
+        if (criterion == null) {
+            return this;
+        }
         return and(this, criterion);
     }
 
     /**
-     * @param criterion another criterion to be appended with OR
+     * @param criterion another criterion to be appended with OR. If null, this Criterion will be returned unmodified.
      * @return a criterion equivalent to (this OR criterion)
      */
     public Criterion or(Criterion criterion) {
+        if (criterion == null) {
+            return this;
+        }
         return or(this, criterion);
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/Delete.java
+++ b/squidb/src/com/yahoo/squidb/sql/Delete.java
@@ -48,6 +48,9 @@ public class Delete extends TableStatement {
      * @return this Delete object, to allow chaining method calls
      */
     public Delete where(Criterion criterion) {
+        if (criterion == null) {
+            return this;
+        }
         this.criterions.add(criterion);
         invalidateCompileCache();
         return this;

--- a/squidb/src/com/yahoo/squidb/sql/Delete.java
+++ b/squidb/src/com/yahoo/squidb/sql/Delete.java
@@ -48,11 +48,10 @@ public class Delete extends TableStatement {
      * @return this Delete object, to allow chaining method calls
      */
     public Delete where(Criterion criterion) {
-        if (criterion == null) {
-            return this;
+        if (criterion != null) {
+            this.criterions.add(criterion);
+            invalidateCompileCache();
         }
-        this.criterions.add(criterion);
-        invalidateCompileCache();
         return this;
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/Function.java
+++ b/squidb/src/com/yahoo/squidb/sql/Function.java
@@ -129,10 +129,10 @@ public abstract class Function<TYPE> extends Field<TYPE> {
     }
 
     /**
-     * Create a Function that counts all rows
+     * Create a Function that counts all rows (i.e. count(*))
      */
     public static Function<Integer> count() {
-        return new ArgumentFunction<Integer>("COUNT", 1);
+        return new RawFunction<Integer>("COUNT(*)");
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/sql/Function.java
+++ b/squidb/src/com/yahoo/squidb/sql/Function.java
@@ -246,6 +246,9 @@ public abstract class Function<TYPE> extends Field<TYPE> {
      * Begins a CASE statement, populating it with the first WHEN ... THEN branch
      */
     public static CaseBuilder caseWhen(Criterion when, Object then) {
+        if (when == null) {
+            throw new IllegalArgumentException("Can't construct a CASE WHEN statement with a null criterion");
+        }
         return new CaseBuilder(null).when(when, then);
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/Join.java
+++ b/squidb/src/com/yahoo/squidb/sql/Join.java
@@ -111,7 +111,7 @@ public class Join extends CompilableWithArguments {
         builder.sql.append(joinType).append(" JOIN ");
         joinTable.appendToSqlBuilder(builder, forSqlValidation);
         builder.sql.append(" ");
-        if (criterions != null) {
+        if (criterions != null && criterions.length > 0) {
             builder.sql.append("ON ");
             for (int i = 0; i < criterions.length; i++) {
                 if (i > 0) {
@@ -119,7 +119,7 @@ public class Join extends CompilableWithArguments {
                 }
                 criterions[i].appendToSqlBuilder(builder, forSqlValidation);
             }
-        } else if (usings != null) {
+        } else if (usings != null && usings.length > 0) {
             builder.sql.append("USING (");
             for (int i = 0; i < usings.length; i++) {
                 if (i > 0) {

--- a/squidb/src/com/yahoo/squidb/sql/NegationCriterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/NegationCriterion.java
@@ -11,6 +11,9 @@ class NegationCriterion extends Criterion {
 
     NegationCriterion(Criterion toNegate) {
         super(Operator.not);
+        if (toNegate == null) {
+            throw new IllegalArgumentException("Can't negate a null criterion");
+        }
         this.toNegate = toNegate;
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/Query.java
+++ b/squidb/src/com/yahoo/squidb/sql/Query.java
@@ -257,6 +257,9 @@ public final class Query extends TableStatement {
      * @return this Query object, to allow chaining method calls
      */
     public Query where(Criterion criterion) {
+        if (criterion == null) {
+            return this;
+        }
         if (immutable) {
             return fork().where(criterion);
         }
@@ -294,6 +297,9 @@ public final class Query extends TableStatement {
      * @return this Query object, to allow chaining method calls
      */
     public Query having(Criterion criterion) {
+        if (criterion == null) {
+            return this;
+        }
         if (immutable) {
             return fork().having(criterion);
         }
@@ -608,6 +614,7 @@ public final class Query extends TableStatement {
      * Return this query wrapped in a Function object, making it suitable for inclusion in another SELECT clause as a
      * subquery or for constructing {@link Criterion}s. Note: the query must have exactly one column in its
      * result set (i.e. one field in the SELECT clause) for this to be valid SQL.
+     *
      * @return a {@link Function} from this query
      */
     public <T> Function<T> asFunction() {

--- a/squidb/src/com/yahoo/squidb/sql/Trigger.java
+++ b/squidb/src/com/yahoo/squidb/sql/Trigger.java
@@ -235,7 +235,9 @@ public class Trigger extends DBObject<Trigger> implements SqlStatement {
      * @return this Trigger instance, for chaining method calls
      */
     public Trigger when(Criterion criterion) {
-        criterions.add(criterion);
+        if (criterion != null) {
+            criterions.add(criterion);
+        }
         return this;
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/Update.java
+++ b/squidb/src/com/yahoo/squidb/sql/Update.java
@@ -69,11 +69,10 @@ public class Update extends TableStatement {
      * @return this Delete object, to allow chaining method calls
      */
     public Update where(Criterion criterion) {
-        if (criterion == null) {
-            return this;
+        if (criterion != null) {
+            this.criterions.add(criterion);
+            invalidateCompileCache();
         }
-        this.criterions.add(criterion);
-        invalidateCompileCache();
         return this;
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/Update.java
+++ b/squidb/src/com/yahoo/squidb/sql/Update.java
@@ -69,6 +69,9 @@ public class Update extends TableStatement {
      * @return this Delete object, to allow chaining method calls
      */
     public Update where(Criterion criterion) {
+        if (criterion == null) {
+            return this;
+        }
         this.criterions.add(criterion);
         invalidateCompileCache();
         return this;


### PR DESCRIPTION
Using literals for these criterions actually had some unexpected performance implications, and they weren't super useful anyways. This PR removes them and updates a few things to replace them:

* Passing a null criterion to methods like deleteWhere or update is now equivalent to "delete all" and "update all". Accordingly, new convenience methods deleteAll and updateAll have been added to SquidDatabase (refs #16, which was closed but will now be better off than it was when 2.0 launches :) )
* Passing null for a Criterion value is handled more gracefully in several places. It is ignored where possible (e.g. query.where(null) is a no-op) and throws an exception where it is very bad (e.g. Criterion.negate(null) is nonsensical, so throws an IllegalArgumentException).

Users who still want the old behavior of Criterion.all (i.e. "WHERE 1") can use Criterion.literal(1) instead.