### PR TITLE
Assorted virtual model fixes

### DIFF
--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
@@ -122,19 +122,20 @@ public abstract class ModelFileWriter<T extends Annotation> {
         }
         if (!modifiers.contains(Modifier.STATIC)) {
             utils.getMessager().printMessage(Kind.WARNING,
-                    "Model spec objects should never be instantiated, so non-static methods are meaningless. Did you mean to make this a static method?",
-                    e);
+                    "Model spec objects should never be instantiated, so non-static methods are meaningless. " +
+                            "Did you mean to make this a static method?", e);
             return;
         }
         ModelMethod methodAnnotation = e.getAnnotation(ModelMethod.class);
-        // Private static methods may be unannotated if they are called by a public annotated method. Don't assume error if method is private
+        // Private static methods may be unannotated if they are called by a public annotated method.
+        // Don't assume error if method is private
         if (methodAnnotation == null) {
             if (modifiers.contains(Modifier.PUBLIC)) {
                 staticModelMethods.add(e);
             } else if (!modifiers.contains(Modifier.PRIVATE)) {
                 utils.getMessager().printMessage(Kind.WARNING,
-                        "This method will not be added to the model definition. Did you mean to annotate this method with @ModelMethod?",
-                        e);
+                        "This method will not be added to the model definition. " +
+                                "Did you mean to annotate this method with @ModelMethod?", e);
             }
         } else {
             List<? extends VariableElement> params = e.getParameters();

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
@@ -85,10 +85,13 @@ public class TableModelFileWriter extends ModelFileWriter<TableModelSpec> {
             if (e.getAnnotation(PrimaryKey.class) != null) {
                 if (!BasicLongPropertyGenerator.handledColumnTypes().contains(typeName)) {
                     utils.getMessager().printMessage(Kind.ERROR,
-                            "Only long primary key columns are supported at this time.", e);
+                            "Only long primary key columns are supported at this time", e);
                 } else if (idPropertyGenerator != null) {
                     utils.getMessager().printMessage(Kind.ERROR,
-                            "Only a single primary key column is supported at this time.", e);
+                            "Only a single primary key column is supported at this time", e);
+                } else if (isVirtualTable()) {
+                    utils.getMessager().printMessage(Kind.ERROR,
+                            "Virtual tables cannot declare a custom primary key", e);
                 } else {
                     idPropertyGenerator = propertyGeneratorForElement(e);
                 }

--- a/squidb-tests/src/com/yahoo/squidb/data/VirtualModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/VirtualModelTest.java
@@ -6,6 +6,7 @@
 package com.yahoo.squidb.data;
 
 import com.yahoo.squidb.sql.Criterion;
+import com.yahoo.squidb.sql.Query;
 import com.yahoo.squidb.test.DatabaseTestCase;
 import com.yahoo.squidb.test.TestVirtualModel;
 
@@ -51,5 +52,20 @@ public class VirtualModelTest extends DatabaseTestCase {
         TestVirtualModel fetched = dao.fetch(TestVirtualModel.class, id, TestVirtualModel.PROPERTIES);
         assertEquals(id, fetched.getId());
         assertEquals(testNum, fetched.getTestNumber());
+    }
+
+    public void testSelectAllIncludesRowid() {
+        // insert
+        TestVirtualModel model = new TestVirtualModel()
+                .setTitle("Charlie")
+                .setBody("Charlie and the Chocolate Factory");
+        assertTrue(dao.createNew(model));
+
+        long expectedId = model.getId();
+
+        TestVirtualModel fetchedModel = dao.fetchByQuery(TestVirtualModel.class, Query.select());
+        assertEquals(expectedId, fetchedModel.getId());
+        assertEquals(model, fetchedModel);
+
     }
 }

--- a/squidb/src/com/yahoo/squidb/sql/Query.java
+++ b/squidb/src/com/yahoo/squidb/sql/Query.java
@@ -6,6 +6,7 @@
 package com.yahoo.squidb.sql;
 
 import com.yahoo.squidb.data.ViewModel;
+import com.yahoo.squidb.sql.Property.LongProperty;
 import com.yahoo.squidb.utility.SquidUtilities;
 
 import java.util.ArrayList;
@@ -513,6 +514,13 @@ public final class Query extends TableStatement {
         }
 
         if (isEmpty(fields)) {
+            // Explicitly add rowid for virtual tables: "select table.rowid as rowid, *"
+            if (table instanceof VirtualTable) {
+                VirtualTable virtualTable = (VirtualTable) table;
+                LongProperty idProperty = virtualTable.getIdProperty();
+                idProperty.appendCompiledStringWithArguments(sql, selectionArgsBuilder);
+                sql.append(", ");
+            }
             sql.append("*");
             return;
         }


### PR DESCRIPTION
This includes two changes:
1) A small tweak to the processor to disallow using the @PrimaryKey annotation in a virtual table model spec (since the primary key in a virtual table is always the rowid).
2) A small enhancement to Query that explicitly includes the table rowid when doing a select * from a virtual table. select * wouldn't include the rowid by default but we don't want to make models fetched from the database appear unpersisted.

Closes #23 