### PR TITLE
Misc 2.0 fixes

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
@@ -60,7 +60,7 @@ public class PropertyTest extends SquidTestCase {
         assertEquals(test1.hashCode(), test2.hashCode());
 
         StringProperty test3 = new StringProperty(TestModel.TABLE, "testCol");
-        StringProperty test4 = new StringProperty(TestModel.TABLE, "testCol", "DEFAULT 'A");
+        StringProperty test4 = new StringProperty(TestModel.TABLE, "testCol", "DEFAULT 'A'");
 
         assertEquals(test3, test4);
         assertEquals(test3.hashCode(), test4.hashCode());

--- a/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
@@ -5,7 +5,11 @@
  */
 package com.yahoo.squidb.data;
 
+import com.yahoo.squidb.sql.Function;
+import com.yahoo.squidb.sql.Property;
+import com.yahoo.squidb.sql.Property.IntegerProperty;
 import com.yahoo.squidb.sql.Property.LongProperty;
+import com.yahoo.squidb.sql.Property.StringProperty;
 import com.yahoo.squidb.sql.Query;
 import com.yahoo.squidb.test.SquidTestCase;
 import com.yahoo.squidb.test.TestModel;
@@ -46,6 +50,32 @@ public class PropertyTest extends SquidTestCase {
         assertEquals(Thing.ID.getQualifiedExpression(), "things.id");
         assertEquals(Thing.ID.getExpression(), "id");
         assertEquals(Thing.ID.getName(), "id");
+    }
+
+    public void testEqualsAndHashCode() {
+        LongProperty test1 = new LongProperty(TestModel.TABLE, "testCol");
+        LongProperty test2 = new LongProperty(TestModel.TABLE, "testCol");
+
+        assertEquals(test1, test2);
+        assertEquals(test1.hashCode(), test2.hashCode());
+
+        StringProperty test3 = new StringProperty(TestModel.TABLE, "testCol");
+        StringProperty test4 = new StringProperty(TestModel.TABLE, "testCol", "DEFAULT 'A");
+
+        assertEquals(test3, test4);
+        assertEquals(test3.hashCode(), test4.hashCode());
+
+        Function<Integer> func1 = Function.count();
+        Function<Integer> func2 = Function.rawFunction("COUNT(*)");
+
+        assertEquals(func1, func2);
+        assertEquals(func1.hashCode(), func2.hashCode());
+
+        IntegerProperty test5 = Property.IntegerProperty.fromFunction(func1, "count");
+        IntegerProperty test6 = Property.IntegerProperty.fromFunction(func2, "count");
+
+        assertEquals(test5, test6);
+        assertEquals(test5.hashCode(), test6.hashCode());
     }
 
 }

--- a/squidb-tests/src/com/yahoo/squidb/test/TestDatabase.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/TestDatabase.java
@@ -77,6 +77,11 @@ public class TestDatabase extends SquidDatabase {
     }
 
     @Override
+    protected void onOpen(SQLiteDatabaseWrapper db) {
+        super.onOpen(db);
+    }
+
+    @Override
     protected void onConfigure(SQLiteDatabaseWrapper db) {
         /** @see AttachDetachTest#testAttacherInTransactionOnAnotherThread() */
         db.enableWriteAheadLogging();

--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -146,11 +146,8 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
      */
     @Override
     public boolean equals(Object other) {
-        if (other == null || other.getClass() != getClass()) {
-            return false;
-        }
-
-        return getMergedValues().equals(((AbstractModel) other).getMergedValues());
+        return other != null && getClass().equals(other.getClass()) && getMergedValues()
+                .equals(((AbstractModel) other).getMergedValues());
     }
 
     @Override
@@ -160,13 +157,9 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append(getClass().getSimpleName()).append("\n")
-                .append("set values:\n")
-                .append(setValues).append("\n")
-                .append("values:\n")
-                .append(values).append("\n");
-        return builder.toString();
+        return getClass().getSimpleName() + "\n" +
+                "set values:\n" + setValues + "\n" +
+                "values:\n" + values + "\n";
     }
 
     @Override
@@ -299,15 +292,7 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
      * @return true if a value for this property has been read from the database or set by the user
      */
     public boolean containsValue(Property<?> property) {
-        if (setValues != null && setValues.containsKey(property.getName())) {
-            return true;
-        }
-
-        if (values != null && values.containsKey(property.getName())) {
-            return true;
-        }
-
-        return false;
+        return valuesContainsKey(setValues, property) || valuesContainsKey(values, property);
     }
 
     /**
@@ -316,15 +301,8 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
      * stored is not null
      */
     public boolean containsNonNullValue(Property<?> property) {
-        if (setValues != null && setValues.containsKey(property.getName())) {
-            return setValues.get(property.getName()) != null;
-        }
-
-        if (values != null && values.containsKey(property.getName())) {
-            return values.get(property.getName()) != null;
-        }
-
-        return false;
+        return (valuesContainsKey(setValues, property) && setValues.get(property.getName()) != null)
+                || (valuesContainsKey(values, property) && values.get(property.getName()) != null);
     }
 
     /**
@@ -332,7 +310,11 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
      * @return true if this property has a value that was set by the user
      */
     public boolean fieldIsDirty(Property<?> property) {
-        return setValues != null && setValues.containsKey(property.getName());
+        return valuesContainsKey(setValues, property);
+    }
+
+    private boolean valuesContainsKey(ContentValues values, Property<?> property) {
+        return values != null && values.containsKey(property.getName());
     }
 
     // --- data storage

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -19,10 +19,10 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.yahoo.squidb.Beta;
-import com.yahoo.squidb.data.adapter.SQLiteOpenHelperWrapper;
 import com.yahoo.squidb.data.adapter.DefaultOpenHelperWrapper;
 import com.yahoo.squidb.data.adapter.SQLExceptionWrapper;
 import com.yahoo.squidb.data.adapter.SQLiteDatabaseWrapper;
+import com.yahoo.squidb.data.adapter.SQLiteOpenHelperWrapper;
 import com.yahoo.squidb.data.adapter.SquidTransactionListener;
 import com.yahoo.squidb.sql.CompiledStatement;
 import com.yahoo.squidb.sql.Criterion;

--- a/squidb/src/com/yahoo/squidb/data/ViewModel.java
+++ b/squidb/src/com/yahoo/squidb/data/ViewModel.java
@@ -173,8 +173,8 @@ public abstract class ViewModel extends AbstractModel {
                 if (base.table instanceof Table && ((Table) base.table).getIdProperty().equals(base)) {
                     alias = base.table.getName() + "Id";
                 } else {
-                    int occurence = numOccurences.get(name);
-                    alias = name + "_" + occurence;
+                    int occurrence = numOccurences.get(name);
+                    alias = name + "_" + occurrence;
                 }
                 aliasedPropertyArray[i] = base.as(alias);
                 numOccurences.put(name, numOccurences.get(name) - 1);

--- a/squidb/src/com/yahoo/squidb/sql/DBObject.java
+++ b/squidb/src/com/yahoo/squidb/sql/DBObject.java
@@ -75,8 +75,8 @@ abstract class DBObject<T extends DBObject<?>> extends CompilableWithArguments i
         if (alias != null ? !alias.equals(dbObject.alias) : dbObject.alias != null) {
             return false;
         }
-        if (getExpression() != null ? !getExpression().equals(dbObject.getExpression())
-                : dbObject.getExpression() != null) {
+        if (expressionForComparison() != null ? !expressionForComparison().equals(dbObject.expressionForComparison())
+                : dbObject.expressionForComparison() != null) {
             return false;
         }
         return !(qualifier != null ? !qualifier.equals(dbObject.qualifier) : dbObject.qualifier != null);
@@ -86,15 +86,24 @@ abstract class DBObject<T extends DBObject<?>> extends CompilableWithArguments i
     @Override
     public int hashCode() {
         int result = alias != null ? alias.hashCode() : 0;
-        result = 31 * result + (getExpression() != null ? getExpression().hashCode() : 0);
+        result = 31 * result + (expressionForComparison() != null ? expressionForComparison().hashCode() : 0);
         result = 31 * result + (qualifier != null ? qualifier.hashCode() : 0);
         return result;
+    }
+
+    /**
+     * @return a string-literal representation of this object suitable for implementing equals() and hashCode(). Most
+     * subclasses will not need to override this; only classes like {@link Function} or {@link Property} where
+     * {@link #getExpression()} is implemented differently need to care about this.
+     */
+    protected String expressionForComparison() {
+        return getExpression();
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("Expression=").append(getExpression());
+        sb.append("Expression=").append(expressionForComparison());
         if (hasQualifier()) {
             sb.append(" Qualifier=").append(qualifier);
         }

--- a/squidb/src/com/yahoo/squidb/sql/DBObject.java
+++ b/squidb/src/com/yahoo/squidb/sql/DBObject.java
@@ -75,20 +75,19 @@ abstract class DBObject<T extends DBObject<?>> extends CompilableWithArguments i
         if (alias != null ? !alias.equals(dbObject.alias) : dbObject.alias != null) {
             return false;
         }
-        String myExpression = getExpression();
-        String otherExpression = dbObject.getExpression();
-        if (myExpression != null ? !myExpression.equals(otherExpression) : otherExpression != null) {
+        if (getExpression() != null ? !getExpression().equals(dbObject.getExpression())
+                : dbObject.getExpression() != null) {
             return false;
         }
+        return !(qualifier != null ? !qualifier.equals(dbObject.qualifier) : dbObject.qualifier != null);
 
-        return true;
     }
 
     @Override
     public int hashCode() {
         int result = alias != null ? alias.hashCode() : 0;
-        String expression = getExpression();
-        result = 31 * result + (expression != null ? expression.hashCode() : 0);
+        result = 31 * result + (getExpression() != null ? getExpression().hashCode() : 0);
+        result = 31 * result + (qualifier != null ? qualifier.hashCode() : 0);
         return result;
     }
 
@@ -126,10 +125,9 @@ abstract class DBObject<T extends DBObject<?>> extends CompilableWithArguments i
      * @return the string-literal representation of this object, prepended with its qualifier (if it has one)
      */
     public final String getQualifiedExpression() {
-        if (hasQualifier()) {
-            return qualifier + '.' + getExpression();
-        }
-        return getExpression();
+        StringBuilder builder = new StringBuilder();
+        appendQualifiedExpressionToStringBuilder(builder);
+        return builder.toString();
     }
 
     /**
@@ -149,6 +147,13 @@ abstract class DBObject<T extends DBObject<?>> extends CompilableWithArguments i
     }
 
     protected void appendQualifiedExpression(SqlBuilder builder, boolean forSqlValidation) {
-        builder.sql.append(getQualifiedExpression());
+        appendQualifiedExpressionToStringBuilder(builder.sql);
+    }
+
+    private void appendQualifiedExpressionToStringBuilder(StringBuilder builder) {
+        if (hasQualifier()) {
+            builder.append(qualifier).append('.');
+        }
+        builder.append(getExpression());
     }
 }

--- a/squidb/src/com/yahoo/squidb/sql/DBObject.java
+++ b/squidb/src/com/yahoo/squidb/sql/DBObject.java
@@ -75,8 +75,10 @@ abstract class DBObject<T extends DBObject<?>> extends CompilableWithArguments i
         if (alias != null ? !alias.equals(dbObject.alias) : dbObject.alias != null) {
             return false;
         }
-        if (expressionForComparison() != null ? !expressionForComparison().equals(dbObject.expressionForComparison())
-                : dbObject.expressionForComparison() != null) {
+        String myExpression = expressionForComparison();
+        String otherExpression = dbObject.expressionForComparison();
+
+        if (myExpression != null ? !myExpression.equals(otherExpression) : otherExpression != null) {
             return false;
         }
         return !(qualifier != null ? !qualifier.equals(dbObject.qualifier) : dbObject.qualifier != null);
@@ -86,7 +88,8 @@ abstract class DBObject<T extends DBObject<?>> extends CompilableWithArguments i
     @Override
     public int hashCode() {
         int result = alias != null ? alias.hashCode() : 0;
-        result = 31 * result + (expressionForComparison() != null ? expressionForComparison().hashCode() : 0);
+        String expression = expressionForComparison();
+        result = 31 * result + (expression != null ? expression.hashCode() : 0);
         result = 31 * result + (qualifier != null ? qualifier.hashCode() : 0);
         return result;
     }

--- a/squidb/src/com/yahoo/squidb/sql/Function.java
+++ b/squidb/src/com/yahoo/squidb/sql/Function.java
@@ -69,6 +69,11 @@ public abstract class Function<TYPE> extends Field<TYPE> {
         return builder.getSqlString();
     }
 
+    @Override
+    protected String expressionForComparison() {
+        return getExpression(VersionCode.LATEST);
+    }
+
     /**
      * Create a Function call with the given name and list of arguments. Returns
      * a function equivalent to "functionName(arg1, arg2, ...)"

--- a/squidb/src/com/yahoo/squidb/sql/Property.java
+++ b/squidb/src/com/yahoo/squidb/sql/Property.java
@@ -93,6 +93,14 @@ public abstract class Property<TYPE> extends Field<TYPE> implements Cloneable {
         return super.getExpression();
     }
 
+    @Override
+    protected String expressionForComparison() {
+        if (function != null) {
+            return function.expressionForComparison();
+        }
+        return super.expressionForComparison();
+    }
+
     /**
      * Accept a {@link PropertyVisitor}
      */

--- a/squidb/src/com/yahoo/squidb/sql/Table.java
+++ b/squidb/src/com/yahoo/squidb/sql/Table.java
@@ -83,10 +83,7 @@ public class Table extends SqlTable<TableModel> {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder(super.toString());
-        sb.append(" ModelClass=").append(modelClass.getSimpleName())
-                .append(" TableConstraint=").append(tableConstraint);
-        return sb.toString();
+        return super.toString() + " ModelClass=" + modelClass.getSimpleName() + " TableConstraint=" + tableConstraint;
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/sql/Trigger.java
+++ b/squidb/src/com/yahoo/squidb/sql/Trigger.java
@@ -10,6 +10,7 @@ import com.yahoo.squidb.utility.SquidUtilities;
 import com.yahoo.squidb.utility.VersionCode;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -250,10 +251,7 @@ public class Trigger extends DBObject<Trigger> implements SqlStatement {
      * @return this Trigger instance, for chaining method calls
      */
     public Trigger perform(TableStatement... statements) {
-        for (TableStatement statement : statements) {
-            // Android's argument binding doesn't handle trigger statements, so we settle for a sanitized sql statement.
-            this.statements.add(statement);
-        }
+        Collections.addAll(this.statements, statements);
         return this;
     }
 
@@ -351,6 +349,7 @@ public class Trigger extends DBObject<Trigger> implements SqlStatement {
     private void visitStatements(SqlBuilder builder) {
         builder.sql.append("BEGIN ");
         for (int i = 0; i < statements.size(); i++) {
+            // Android's argument binding doesn't handle trigger statements, so we settle for a sanitized sql statement.
             builder.sql.append(statements.get(i).toRawSql(builder.sqliteVersion)).append("; ");
         }
         builder.sql.append("END");

--- a/squidb/src/com/yahoo/squidb/sql/VirtualTable.java
+++ b/squidb/src/com/yahoo/squidb/sql/VirtualTable.java
@@ -61,10 +61,7 @@ public class VirtualTable extends Table {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder(super.toString());
-        sb.append(" ModelClass=").append(modelClass.getSimpleName())
-                .append(" module=").append(moduleName);
-        return sb.toString();
+        return super.toString() + " ModelClass=" + modelClass.getSimpleName() + " module=" + moduleName;
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/utility/SquidUtilities.java
+++ b/squidb/src/com/yahoo/squidb/utility/SquidUtilities.java
@@ -9,6 +9,8 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.util.Log;
 
+import com.yahoo.squidb.data.SquidDatabase;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -71,20 +73,21 @@ public class SquidUtilities {
     /**
      * Copy database files to the given folder. Useful for debugging.
      *
-     * @param folder the directory to copy files into
+     * @param context a Context
+     * @param database the SquidDatabase to copy
+     * @param toFolder the directory to copy files into
      */
-    public static void copyDatabases(Context context, String folder) {
-        File folderFile = new File(folder);
-        if (!folderFile.exists()) {
-            folderFile.mkdir();
+    public static void copyDatabase(Context context, SquidDatabase database, String toFolder) {
+        File folderFile = new File(toFolder);
+        if (!(folderFile.mkdirs() || folderFile.isDirectory())) {
+            Log.e("squidb", "Error creating directories for database copy");
+            return;
         }
-        for (String db : context.databaseList()) {
-            File dbFile = context.getDatabasePath(db);
-            try {
-                copyFile(dbFile, new File(folderFile.getAbsolutePath() + File.separator + db));
-            } catch (Exception e) {
-                Log.e("ERROR", "ERROR COPYING DB " + db, e);
-            }
+        File dbFile = context.getDatabasePath(database.getName());
+        try {
+            copyFile(dbFile, new File(folderFile.getAbsolutePath() + File.separator + database.getName()));
+        } catch (Exception e) {
+            Log.e("squidb", "Error copying database " + database.getName(), e);
         }
     }
 

--- a/squidb/src/com/yahoo/squidb/utility/VersionCode.java
+++ b/squidb/src/com/yahoo/squidb/utility/VersionCode.java
@@ -211,6 +211,9 @@ public class VersionCode implements Comparable<VersionCode> {
         builder.append(Integer.toString(majorVersion))
                 .append('.').append(Integer.toString(minorVersion))
                 .append('.').append(Integer.toString(microVersion));
+        if (nanoVersion > 0) {
+            builder.append('.').append(nanoVersion);
+        }
         if (!TextUtils.isEmpty(trailing)) {
             builder.append(trailing);
         }


### PR DESCRIPTION
This fixes an issue with DBObject hashCode and equals--they relied on getExpression(), but Function and function properties don't support getExpression(). This fixes that bug as well as a few miscellaneous warnings.