### PR TITLE
Gradle version flexibility

### DIFF
--- a/squidb-addons/squidb-jackson-plugin/build.gradle
+++ b/squidb-addons/squidb-jackson-plugin/build.gradle
@@ -14,7 +14,11 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        if (gradle.gradleVersion.startsWith('2.2') || gradle.gradleVersion.startsWith('2.3')) {
+            classpath 'com.github.dcendents:android-maven-plugin:1.2'
+        } else {
+            classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        }
     }
 }
 

--- a/squidb-addons/squidb-sqlite-bindings/build.gradle
+++ b/squidb-addons/squidb-sqlite-bindings/build.gradle
@@ -14,7 +14,11 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        if (gradle.gradleVersion.startsWith('2.2') || gradle.gradleVersion.startsWith('2.3')) {
+            classpath 'com.github.dcendents:android-maven-plugin:1.2'
+        } else {
+            classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        }
     }
 }
 

--- a/squidb/build.gradle
+++ b/squidb/build.gradle
@@ -14,7 +14,11 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        if (gradle.gradleVersion.startsWith('2.2') || gradle.gradleVersion.startsWith('2.3')) {
+            classpath 'com.github.dcendents:android-maven-plugin:1.2'
+        } else {
+            classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        }
     }
 }
 


### PR DESCRIPTION
Apply the correct version of the android-maven gradle plugin for the current version of gradle. This allows people building from source to use whatever gradle version they want between 2.2 and 2.5 to build from source, since this plugin version was the only thing standing in the way of that.