### PR TITLE
Fieldless property generators

### DIFF
--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicBlobPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicBlobPropertyGenerator.java
@@ -24,6 +24,15 @@ public class BasicBlobPropertyGenerator extends BasicPropertyGenerator {
         return Collections.singletonList(TypeConstants.BYTE_ARRAY);
     }
 
+    public BasicBlobPropertyGenerator(ModelSpec<?> modelSpec, String columnName, AptUtils utils) {
+        super(modelSpec, columnName, utils);
+    }
+
+    public BasicBlobPropertyGenerator(ModelSpec<?> modelSpec, String columnName,
+            String propertyName, AptUtils utils) {
+        super(modelSpec, columnName, propertyName, utils);
+    }
+
     public BasicBlobPropertyGenerator(ModelSpec<?> modelSpec, VariableElement field, AptUtils utils) {
         super(modelSpec, field, utils);
     }

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicBooleanPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicBooleanPropertyGenerator.java
@@ -26,6 +26,15 @@ public class BasicBooleanPropertyGenerator extends BasicPropertyGenerator {
         return Arrays.asList(CoreTypes.JAVA_BOOLEAN, CoreTypes.PRIMITIVE_BOOLEAN);
     }
 
+    public BasicBooleanPropertyGenerator(ModelSpec<?> modelSpec, String columnName, AptUtils utils) {
+        super(modelSpec, columnName, utils);
+    }
+
+    public BasicBooleanPropertyGenerator(ModelSpec<?> modelSpec, String columnName,
+            String propertyName, AptUtils utils) {
+        super(modelSpec, columnName, propertyName, utils);
+    }
+
     public BasicBooleanPropertyGenerator(ModelSpec<?> modelSpec, VariableElement field, AptUtils utils) {
         super(modelSpec, field, utils);
     }

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicDoublePropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicDoublePropertyGenerator.java
@@ -26,6 +26,15 @@ public class BasicDoublePropertyGenerator extends BasicPropertyGenerator {
                 CoreTypes.JAVA_DOUBLE, CoreTypes.PRIMITIVE_DOUBLE);
     }
 
+    public BasicDoublePropertyGenerator(ModelSpec<?> modelSpec, String columnName, AptUtils utils) {
+        super(modelSpec, columnName, utils);
+    }
+
+    public BasicDoublePropertyGenerator(ModelSpec<?> modelSpec, String columnName,
+            String propertyName, AptUtils utils) {
+        super(modelSpec, columnName, propertyName, utils);
+    }
+
     public BasicDoublePropertyGenerator(ModelSpec<?> modelSpec, VariableElement field, AptUtils utils) {
         super(modelSpec, field, utils);
     }

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicIntegerPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicIntegerPropertyGenerator.java
@@ -26,6 +26,15 @@ public class BasicIntegerPropertyGenerator extends BasicPropertyGenerator {
                 CoreTypes.PRIMITIVE_BYTE, CoreTypes.PRIMITIVE_SHORT, CoreTypes.PRIMITIVE_INT);
     }
 
+    public BasicIntegerPropertyGenerator(ModelSpec<?> modelSpec, String columnName, AptUtils utils) {
+        super(modelSpec, columnName, utils);
+    }
+
+    public BasicIntegerPropertyGenerator(ModelSpec<?> modelSpec, String columnName,
+            String propertyName, AptUtils utils) {
+        super(modelSpec, columnName, propertyName, utils);
+    }
+
     public BasicIntegerPropertyGenerator(ModelSpec<?> modelSpec, VariableElement field, AptUtils utils) {
         super(modelSpec, field, utils);
     }

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicLongPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicLongPropertyGenerator.java
@@ -29,6 +29,15 @@ public class BasicLongPropertyGenerator extends BasicPropertyGenerator {
         return Arrays.asList(CoreTypes.JAVA_LONG, CoreTypes.PRIMITIVE_LONG);
     }
 
+    public BasicLongPropertyGenerator(ModelSpec<?> modelSpec, String columnName, AptUtils utils) {
+        super(modelSpec, columnName, utils);
+    }
+
+    public BasicLongPropertyGenerator(ModelSpec<?> modelSpec, String columnName,
+            String propertyName, AptUtils utils) {
+        super(modelSpec, columnName, propertyName, utils);
+    }
+
     public BasicLongPropertyGenerator(ModelSpec<?> modelSpec, VariableElement field, AptUtils utils) {
         super(modelSpec, field, utils);
 

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicPropertyGenerator.java
@@ -36,14 +36,34 @@ public abstract class BasicPropertyGenerator extends PropertyGenerator {
     protected final String camelCasePropertyName;
     protected final String columnName;
 
+    public BasicPropertyGenerator(ModelSpec<?> modelSpec, String columnName, AptUtils utils) {
+        this(modelSpec, columnName, columnName, utils);
+    }
+
+    public BasicPropertyGenerator(ModelSpec<?> modelSpec, String columnName, String propertyName, AptUtils utils) {
+        super(modelSpec, null, utils);
+        this.extras = null;
+
+        this.camelCasePropertyName = StringUtils.toCamelCase(propertyName);
+        this.propertyName = StringUtils.toUpperUnderscore(camelCasePropertyName);
+        this.columnName = columnName;
+
+        validateColumnName();
+    }
+
     public BasicPropertyGenerator(ModelSpec<?> modelSpec, VariableElement field, AptUtils utils) {
         super(modelSpec, field, utils);
         this.extras = field.getAnnotation(ColumnSpec.class);
         String name = field.getSimpleName().toString();
+
         this.camelCasePropertyName = StringUtils.toCamelCase(name);
         this.propertyName = StringUtils.toUpperUnderscore(camelCasePropertyName);
         this.columnName = getColumnName(extras);
 
+        validateColumnName();
+    }
+
+    private void validateColumnName() {
         if (columnName.indexOf('$') >= 0) {
             utils.getMessager().printMessage(Kind.ERROR, "Column names cannot contain the $ symbol", field);
         } else if (Character.isDigit(columnName.charAt(0))) {

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicStringPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicStringPropertyGenerator.java
@@ -26,6 +26,15 @@ public class BasicStringPropertyGenerator extends BasicPropertyGenerator {
         return Collections.singletonList(CoreTypes.JAVA_STRING);
     }
 
+    public BasicStringPropertyGenerator(ModelSpec<?> modelSpec, String columnName, AptUtils utils) {
+        super(modelSpec, columnName, utils);
+    }
+
+    public BasicStringPropertyGenerator(ModelSpec<?> modelSpec, String columnName,
+            String propertyName, AptUtils utils) {
+        super(modelSpec, columnName, propertyName, utils);
+    }
+
     public BasicStringPropertyGenerator(ModelSpec<?> modelSpec, VariableElement field, AptUtils utils) {
         super(modelSpec, field, utils);
     }

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/PropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/PropertyGenerator.java
@@ -39,7 +39,8 @@ public abstract class PropertyGenerator {
     }
 
     /**
-     * @return the {@link VariableElement} this PropertyGenerator was created from
+     * @return the {@link VariableElement} this PropertyGenerator was created from. This may be null if the
+     * PropertyGenerator did not originate from a VariableElement in a model spec
      */
     public VariableElement getField() {
         return field;

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/PropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/PropertyGenerator.java
@@ -35,7 +35,7 @@ public abstract class PropertyGenerator {
         this.modelSpec = modelSpec;
         this.field = field;
         this.utils = utils;
-        this.isDeprecated = field.getAnnotation(Deprecated.class) != null;
+        this.isDeprecated = field != null && field.getAnnotation(Deprecated.class) != null;
     }
 
     /**
@@ -67,8 +67,8 @@ public abstract class PropertyGenerator {
 
     /**
      * Called before {@link #emitPropertyDeclaration(JavaFileWriter)}
+     *
      * @param writer a {@link JavaFileWriter} for writing to
-     * @throws IOException
      */
     public void beforeEmitPropertyDeclaration(JavaFileWriter writer) throws IOException {
         // Subclasses can override
@@ -76,15 +76,15 @@ public abstract class PropertyGenerator {
 
     /**
      * Called to write the declaration of the property itself
+     *
      * @param writer a {@link JavaFileWriter} for writing to
-     * @throws IOException
      */
     public abstract void emitPropertyDeclaration(JavaFileWriter writer) throws IOException;
 
     /**
      * Called after {@link #emitPropertyDeclaration(JavaFileWriter)}
+     *
      * @param writer a {@link JavaFileWriter} for writing to
-     * @throws IOException
      */
     public void afterEmitPropertyDeclaration(JavaFileWriter writer) throws IOException {
         // Subclasses can override
@@ -92,8 +92,8 @@ public abstract class PropertyGenerator {
 
     /**
      * Called before {@link #emitGetter(JavaFileWriter)}
+     *
      * @param writer a {@link JavaFileWriter} for writing to
-     * @throws IOException
      */
     public void beforeEmitGetter(JavaFileWriter writer) throws IOException {
         // Subclasses can override
@@ -101,15 +101,15 @@ public abstract class PropertyGenerator {
 
     /**
      * Called to write the convenience getter the property itself
+     *
      * @param writer a {@link JavaFileWriter} for writing to
-     * @throws IOException
      */
     public abstract void emitGetter(JavaFileWriter writer) throws IOException;
 
     /**
      * Called after {@link #emitGetter(JavaFileWriter)}
+     *
      * @param writer a {@link JavaFileWriter} for writing to
-     * @throws IOException
      */
     public void afterEmitGetter(JavaFileWriter writer) throws IOException {
         // Subclasses can override
@@ -117,8 +117,8 @@ public abstract class PropertyGenerator {
 
     /**
      * Called before {@link #emitSetter(JavaFileWriter)}
+     *
      * @param writer a {@link JavaFileWriter} for writing to
-     * @throws IOException
      */
     public void beforeEmitSetter(JavaFileWriter writer) throws IOException {
         // Subclasses can override
@@ -126,15 +126,15 @@ public abstract class PropertyGenerator {
 
     /**
      * Called to write the convenience setter the property itself
+     *
      * @param writer a {@link JavaFileWriter} for writing to
-     * @throws IOException
      */
     public abstract void emitSetter(JavaFileWriter writer) throws IOException;
 
     /**
      * Called after {@link #emitSetter(JavaFileWriter)}
+     *
      * @param writer a {@link JavaFileWriter} for writing to
-     * @throws IOException
      */
     public void afterEmitSetter(JavaFileWriter writer) throws IOException {
         // Subclasses can override
@@ -142,9 +142,9 @@ public abstract class PropertyGenerator {
 
     /**
      * Called to emit a call to ContentValues.put for adding a property default to the model default values
+     *
      * @param writer a {@link JavaFileWriter} for writing to
      * @param contentValuesName the name of the content values variable to call
-     * @throws IOException
      */
     public abstract void emitPutDefault(JavaFileWriter writer, String contentValuesName) throws IOException;
 

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/ViewModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/ViewModelFileWriter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 
 public class ViewModelFileWriter extends ModelFileWriter<ViewModelSpecWrapper> {
 
@@ -88,9 +89,12 @@ public class ViewModelFileWriter extends ModelFileWriter<ViewModelSpecWrapper> {
             Expression reference = Expressions.staticReference(modelSpec.getModelSpecName(),
                     propertyGenerator.getPropertyName());
             if (alias) {
-                Alias aliasAnnotation = propertyGenerator.getField().getAnnotation(Alias.class);
-                if (aliasAnnotation != null && !AptUtils.isEmpty(aliasAnnotation.value())) {
-                    reference = reference.callMethod("as", "\"" + aliasAnnotation.value() + "\"");
+                VariableElement field = propertyGenerator.getField();
+                if (field != null) {
+                    Alias aliasAnnotation = field.getAnnotation(Alias.class);
+                    if (aliasAnnotation != null && !AptUtils.isEmpty(aliasAnnotation.value())) {
+                        reference = reference.callMethod("as", "\"" + aliasAnnotation.value() + "\"");
+                    }
                 }
             }
             writer.writeExpression(reference);


### PR DESCRIPTION
Allow creating BasicPropertyGenerators that don't originate from a field in a model spec. This supports a class of plugins that want to add fields to models that don't directly correspond to VariableElements in the model spec.