### PR TITLE
Misc enhancements

### DIFF
--- a/squidb-addons/squidb-sqlite-bindings/src/com/yahoo/squidb/sqlitebindings/SQLiteBindingsCursorFactory.java
+++ b/squidb-addons/squidb-sqlite-bindings/src/com/yahoo/squidb/sqlitebindings/SQLiteBindingsCursorFactory.java
@@ -7,7 +7,7 @@ package com.yahoo.squidb.sqlitebindings;
 
 import android.database.Cursor;
 
-import com.yahoo.squidb.data.adapter.SquidCursorFactory;
+import com.yahoo.squidb.sql.SqlUtils;
 
 import org.sqlite.database.sqlite.SQLiteCursor;
 import org.sqlite.database.sqlite.SQLiteCursorDriver;
@@ -41,7 +41,7 @@ public class SQLiteBindingsCursorFactory implements CursorFactory {
             return;
         }
         for (int i = 1; i <= sqlArgs.length; i++) {
-            Object arg = SquidCursorFactory.resolveArgReferences(sqlArgs[i - 1]);
+            Object arg = SqlUtils.resolveArgReferences(sqlArgs[i - 1]);
             bindObjectToProgram(program, i, arg);
         }
     }

--- a/squidb-annotations/src/com/yahoo/squidb/annotations/ColumnSpec.java
+++ b/squidb-annotations/src/com/yahoo/squidb/annotations/ColumnSpec.java
@@ -14,8 +14,8 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface ColumnSpec {
 
-    public static final String DEFAULT_NONE = "!NONE!";
-    public static final String DEFAULT_NULL = "!NULL!";
+    String DEFAULT_NONE = "!NONE!";
+    String DEFAULT_NULL = "!NULL!";
 
     /**
      * Specify a column name here if you want your property to have a different column name in the SQL table than its

--- a/squidb-tests/src/com/yahoo/squidb/sql/CriterionTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/CriterionTest.java
@@ -8,6 +8,7 @@ package com.yahoo.squidb.sql;
 import com.yahoo.squidb.test.SquidTestCase;
 import com.yahoo.squidb.test.TestModel;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 public class CriterionTest extends SquidTestCase {
@@ -29,7 +30,7 @@ public class CriterionTest extends SquidTestCase {
         assertEquals(c2, c2.negate().negate());
     }
 
-    public void testInstanceVsStaticAnd() {
+    public void testInstanceVsStaticConjunction() {
         Criterion c1 = TestModel.FIRST_NAME.eq("Sam");
         Criterion c2 = TestModel.LAST_NAME.eq("Bosley");
         Criterion c3 = TestModel.LUCKY_NUMBER.eq(7);
@@ -39,7 +40,9 @@ public class CriterionTest extends SquidTestCase {
         assertNotSame(c, cand); // Tests immutability of conjunction criterions when appending with the same operator
 
         assertEquals(Criterion.and(c1, c2, c3), c1.and(c2).and(c3));
+        assertEquals(Criterion.and(Arrays.asList(c1, c2, c3)), c1.and(c2).and(c3));
         assertEquals(Criterion.or(c1, c2, c3), c1.or(c2).or(c3));
+        assertEquals(Criterion.or(Arrays.asList(c1, c2, c3)), c1.or(c2).or(c3));
 
         assertEquals(Criterion.or(Criterion.and(c1, c2), c3), c1.and(c2).or(c3));
         assertEquals(Criterion.and(Criterion.or(c1, c2), c3), c1.or(c2).and(c3));

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -589,6 +589,18 @@ public abstract class SquidDatabase {
     protected long insert(String table, String nullColumnHack, ContentValues values) {
         acquireNonExclusiveLock();
         try {
+            return getDatabase().insert(table, nullColumnHack, values);
+        } finally {
+            releaseNonExclusiveLock();
+        }
+    }
+
+    /**
+     * @see SQLiteDatabase#insertOrThrow(String table, String nullColumnHack, ContentValues values)
+     */
+    protected long insertOrThrow(String table, String nullColumnHack, ContentValues values) {
+        acquireNonExclusiveLock();
+        try {
             return getDatabase().insertOrThrow(table, nullColumnHack, values);
         } finally {
             releaseNonExclusiveLock();
@@ -1684,7 +1696,7 @@ public abstract class SquidDatabase {
             return false;
         }
         if (conflictAlgorithm == null) {
-            newRow = insert(table.getExpression(), null, mergedValues);
+            newRow = insertOrThrow(table.getExpression(), null, mergedValues);
         } else {
             newRow = insertWithOnConflict(table.getExpression(), null, mergedValues,
                     conflictAlgorithm.getAndroidValue());

--- a/squidb/src/com/yahoo/squidb/data/adapter/SquidCursorFactory.java
+++ b/squidb/src/com/yahoo/squidb/data/adapter/SquidCursorFactory.java
@@ -55,6 +55,8 @@ public class SquidCursorFactory implements CursorFactory {
             } else if (arg instanceof AtomicBoolean) { // Not a subclass of Number so DatabaseUtils won't handle it
                 arg = ((AtomicBoolean) arg).get() ? 1 : 0;
                 resolved = true;
+            } else if (arg instanceof ThreadLocal) {
+                arg = ((ThreadLocal<?>) arg).get();
             } else {
                 resolved = true;
             }

--- a/squidb/src/com/yahoo/squidb/data/adapter/SquidCursorFactory.java
+++ b/squidb/src/com/yahoo/squidb/data/adapter/SquidCursorFactory.java
@@ -14,8 +14,7 @@ import android.database.sqlite.SQLiteDatabase.CursorFactory;
 import android.database.sqlite.SQLiteProgram;
 import android.database.sqlite.SQLiteQuery;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
+import com.yahoo.squidb.sql.SqlUtils;
 
 /**
  * A custom cursor factory that ensures query arguments are bound as their native types, rather than as strings. The
@@ -42,25 +41,8 @@ public class SquidCursorFactory implements CursorFactory {
             return;
         }
         for (int i = 1; i <= sqlArgs.length; i++) {
-            Object arg = resolveArgReferences(sqlArgs[i - 1]);
+            Object arg = SqlUtils.resolveArgReferences(sqlArgs[i - 1]);
             DatabaseUtils.bindObjectToProgram(program, i, arg);
         }
-    }
-
-    public static Object resolveArgReferences(Object arg) {
-        boolean resolved = false;
-        while (!resolved) {
-            if (arg instanceof AtomicReference) {
-                arg = ((AtomicReference<?>) arg).get();
-            } else if (arg instanceof AtomicBoolean) { // Not a subclass of Number so DatabaseUtils won't handle it
-                arg = ((AtomicBoolean) arg).get() ? 1 : 0;
-                resolved = true;
-            } else if (arg instanceof ThreadLocal) {
-                arg = ((ThreadLocal<?>) arg).get();
-            } else {
-                resolved = true;
-            }
-        }
-        return arg;
     }
 }

--- a/squidb/src/com/yahoo/squidb/sql/Criterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/Criterion.java
@@ -12,6 +12,7 @@ import com.yahoo.squidb.utility.SquidUtilities;
 import com.yahoo.squidb.utility.VersionCode;
 
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Criterions are primarily used to construct the WHERE clause of a SQL statement. Most criterion objects can be
@@ -50,10 +51,24 @@ public abstract class Criterion extends CompilableWithArguments {
     }
 
     /**
+     * @return a {@link Criterion} that combines the given criterions with AND
+     */
+    public static Criterion and(List<Criterion> criterions) {
+        return new ConjunctionCriterion(Operator.and, criterions);
+    }
+
+    /**
      * @return a {@link Criterion} that combines the given criterions with OR
      */
     public static Criterion or(Criterion criterion, Criterion... criterions) {
         return new ConjunctionCriterion(Operator.or, criterion, criterions);
+    }
+
+    /**
+     * @return a {@link Criterion} that combines the given criterions with OR
+     */
+    public static Criterion or(List<Criterion> criterions) {
+        return new ConjunctionCriterion(Operator.or, criterions);
     }
 
     /**


### PR DESCRIPTION
A bunch of minor changes for better consistency. Makes sure SquidDatabase wraps insert/insertOrThrow correctly and distinguishes between the two, and unifies some duplicated logic in SqlUtils.

ThreadLocals are now accepted as arguments to criterions, which is a step towards better reuse of statements in a multi-threaded environment.

Also adds the ability to construct ConjunctionCriterions from Lists.