### PR TITLE
WAL test

### DIFF
--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -9,6 +9,7 @@ import android.content.ContentValues;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import com.yahoo.squidb.sql.Field;
 import com.yahoo.squidb.sql.Property;
 import com.yahoo.squidb.sql.Property.PropertyVisitor;
 import com.yahoo.squidb.sql.Property.PropertyWritingVisitor;
@@ -213,7 +214,7 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
     public void readPropertiesFromCursor(SquidCursor<?> cursor) {
         prepareToReadProperties();
 
-        for (com.yahoo.squidb.sql.Field<?> field : cursor.getFields()) {
+        for (Field<?> field : cursor.getFields()) {
             readFieldIntoModel(cursor, field);
         }
     }

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -188,9 +188,16 @@ public abstract class SquidDatabase {
 
     /**
      * Called when the database connection is being configured, to enable features such as write-ahead logging or
-     * foreign key support. This method is called before {@link #onTablesCreated(SQLiteDatabaseWrapper) onTablesCreated},
-     * {@link #onUpgrade(SQLiteDatabaseWrapper, int, int) onUpgrade}, {@link #onDowngrade(SQLiteDatabaseWrapper, int, int)
-     * onDowngrade}, and {@link #onOpen(SQLiteDatabaseWrapper) onOpen}.
+     * foreign key support.
+     *
+     * This method may be called at different points in the database lifecycle depending on the environment. When using
+     * a custom SQLite build with the squidb-sqlite-bindings project, or when running on Android API >= 16, it is
+     * called before {@link #onTablesCreated(SQLiteDatabaseWrapper) onTablesCreated},
+     * {@link #onUpgrade(SQLiteDatabaseWrapper, int, int) onUpgrade},
+     * {@link #onDowngrade(SQLiteDatabaseWrapper, int, int) onDowngrade},
+     * and {@link #onOpen(SQLiteDatabaseWrapper) onOpen}. If it is running on stock Android SQLite and API < 16, it
+     * is called after onConfigure. The discrepancy is because onConfigure was only introduced as a callback in API 16,
+     * but the ordering should not matter much for most use cases.
      * <p>
      * This method should only call methods that configure the parameters of the database connection, such as
      * {@link SQLiteDatabaseWrapper#enableWriteAheadLogging}, {@link SQLiteDatabaseWrapper#setForeignKeyConstraintsEnabled},

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -196,8 +196,8 @@ public abstract class SquidDatabase {
      * {@link #onUpgrade(SQLiteDatabaseWrapper, int, int) onUpgrade},
      * {@link #onDowngrade(SQLiteDatabaseWrapper, int, int) onDowngrade},
      * and {@link #onOpen(SQLiteDatabaseWrapper) onOpen}. If it is running on stock Android SQLite and API < 16, it
-     * is called after onConfigure. The discrepancy is because onConfigure was only introduced as a callback in API 16,
-     * but the ordering should not matter much for most use cases.
+     * is called immediately before onOpen but after the other callbacks. The discrepancy is because onConfigure was
+     * only introduced as a callback in API 16, but the ordering should not matter much for most use cases.
      * <p>
      * This method should only call methods that configure the parameters of the database connection, such as
      * {@link SQLiteDatabaseWrapper#enableWriteAheadLogging}, {@link SQLiteDatabaseWrapper#setForeignKeyConstraintsEnabled},

--- a/squidb/src/com/yahoo/squidb/data/adapter/DefaultOpenHelperWrapper.java
+++ b/squidb/src/com/yahoo/squidb/data/adapter/DefaultOpenHelperWrapper.java
@@ -55,10 +55,10 @@ public class DefaultOpenHelperWrapper extends SQLiteOpenHelper implements SQLite
     @Override
     public void onOpen(SQLiteDatabase db) {
         SQLiteDatabaseAdapter adapter = new SQLiteDatabaseAdapter(db);
-        delegate.onOpen(adapter);
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
             delegate.onConfigure(adapter);
         }
+        delegate.onOpen(adapter);
     }
 
 }

--- a/squidb/src/com/yahoo/squidb/data/adapter/DefaultOpenHelperWrapper.java
+++ b/squidb/src/com/yahoo/squidb/data/adapter/DefaultOpenHelperWrapper.java
@@ -8,6 +8,7 @@ package com.yahoo.squidb.data.adapter;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.os.Build;
 
 import com.yahoo.squidb.data.SquidDatabase;
 
@@ -53,7 +54,11 @@ public class DefaultOpenHelperWrapper extends SQLiteOpenHelper implements SQLite
 
     @Override
     public void onOpen(SQLiteDatabase db) {
-        delegate.onOpen(new SQLiteDatabaseAdapter(db));
+        SQLiteDatabaseAdapter adapter = new SQLiteDatabaseAdapter(db);
+        delegate.onOpen(adapter);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+            delegate.onConfigure(adapter);
+        }
     }
 
 }


### PR DESCRIPTION
I added a test case that ensures concurrent reads with WAL were always working, and I discovered that such a test would fail on API 15 because we enable WAL in onConfigure, which was added in API 16. I thought we could patch this at the open helper level by having the open helper for stock android manually call onConfigure after onOpen. @jdkoren what do you think? It seems like a nice convenience for older API levels still be able to use the onConfigure hook. The order of callbacks will be slightly different pre-16, but I doubt that would matter much for most use cases.