### PR TITLE
Initialise copied constants after everything else

### DIFF
--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ConstantCopyingPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ConstantCopyingPlugin.java
@@ -53,7 +53,7 @@ public class ConstantCopyingPlugin extends Plugin {
     }
 
     @Override
-    public void beforeEmitSchema(JavaFileWriter writer) throws IOException {
+    public void afterEmitSchema(JavaFileWriter writer) throws IOException {
         writer.writeComment("--- constants");
         for (VariableElement constant : constantElements) {
             writer.writeFieldDeclaration(

--- a/squidb-tests/src/com/yahoo/squidb/data/ModelDependentSpecTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelDependentSpecTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.data;
+
+import com.yahoo.squidb.test.DatabaseTestCase;
+import com.yahoo.squidb.test.ModelDependent;
+
+public class ModelDependentSpecTest extends DatabaseTestCase {
+
+    public void testModelDependentConstantIsAccessible() {
+        try {
+            ModelDependent.DEFAULT_ORDER.getClass();
+        } catch (ExceptionInInitializerError e) {
+            fail("The generated model must define constants that depend on other constants after " +
+                 "their dependencies. Fields marked `static final` are initialised in the order " +
+                 "they appear in the source.");
+        }
+    }
+
+}

--- a/squidb-tests/src/com/yahoo/squidb/test/ModelDependentSpec.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/ModelDependentSpec.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.test;
+
+import com.yahoo.squidb.annotations.TableModelSpec;
+import com.yahoo.squidb.sql.Order;
+
+@TableModelSpec(className = "ModelDependent", tableName = "modelDependents")
+public class ModelDependentSpec {
+
+    /**
+     * Constant that depends on constants defined in the model.
+     */
+    public static final Order DEFAULT_ORDER = ModelDependent.NAME.asc();
+
+    String name;
+
+}


### PR DESCRIPTION
Hello!

I found a slight problem with the generated initialisation order for constants after I tried to reference some properties in them.

I fixed it by modifying the processor plugin to write the constants just before the constructors. A test case is also included.

Thanks for the excellent work with the library!

*****

This makes it possible to reference e.g. properties defined in the generated
model from constants in the spec. Some useful use cases for such constants
include defining a natural order for the model or some commonly used queries so
that they can be accessed easily.

If these are defined before the `static final` class variables they're trying to
reference, it will lead to unexpected behaviour since those dependencies will be
`null`.

For instance, the following seems to work fine when defined in a spec and used
from a model, but only because `Query.select` defaults to selecting everything
when the parameter is `null`:

```java
public static final QUERY_ALL = Query.select(Model.PROPERTIES).freeze();
```

The following, on the other hand, will crash with a `NullPointerException` since
`Model.ID` hasn't been initialised yet:

```java
public static final DEFAULT_ORDER = Model.ID.asc();
```

Detailed information about the initialisation order of class variables can be
found in the [Java Language Specification][1].

[1]: https://docs.oracle.com/javase/specs/jls/se7/html/jls-8.html#jls-8.3.2.1