### PR TITLE
Add the @Constants annotation for constant holding static inner classes in

### DIFF
--- a/squidb-annotations/src/com/yahoo/squidb/annotations/Constants.java
+++ b/squidb-annotations/src/com/yahoo/squidb/annotations/Constants.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * By default, public static final fields in model spec classes are copied to the generated model classes as constants.
+ * However, if these constants reference fields in the generated model (e.g. properties), there may be issues with the
+ * order of class loading if the generated models refer back to the model spec before the models themselves are fully
+ * initialized. To work around this issue, constants may be declared in a public static inner class in the model
+ * spec and annotated with @Constants. This inner class will not be loaded until all generated model fields are
+ * initialized.
+ * <p>
+ * Any constants that need to refer to the model schema (particularly in a view model) should be declared
+ * in a static inner class as in this example:
+ * <pre>
+ *     &#064;ViewModelSpec(className = "PersonViewModel", viewName = "people")
+ *     public class PersonViewSpecSpec {
+ *
+ *          public static final StringProperty NAME = Person.NAME;
+ *
+ *          &#064;Constants
+ *          public static class Const {
+ *              public static final Order DEFAULT_ORDER = PersonViewModel.NAME.asc();
+ *          }
+ *     }
+ * </pre>
+ */
+@Target(ElementType.TYPE)
+public @interface Constants {
+}

--- a/squidb-processor/src/com/yahoo/squidb/processor/data/ModelSpec.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/data/ModelSpec.java
@@ -71,8 +71,7 @@ public abstract class ModelSpec<T extends Annotation> {
     }
 
     private void processVariableElements() {
-        List<? extends Element> enclosedElements = modelSpecElement.getEnclosedElements();
-        for (Element e : enclosedElements) {
+        for (Element e : modelSpecElement.getEnclosedElements()) {
             if (e instanceof VariableElement && e.getAnnotation(Ignore.class) == null) {
                 TypeName typeName = utils.getTypeNameFromTypeMirror(e.asType());
                 if (!(typeName instanceof DeclaredTypeName)) {
@@ -95,7 +94,6 @@ public abstract class ModelSpec<T extends Annotation> {
      * @return the name of the superclass for the generated model
      */
     public abstract DeclaredTypeName getModelSuperclass();
-
 
     /**
      * Adds imports required by this model spec to the given accumulator set

--- a/squidb-tests/src/com/yahoo/squidb/data/ModelDependentSpecTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelDependentSpecTest.java
@@ -7,6 +7,7 @@ package com.yahoo.squidb.data;
 
 import com.yahoo.squidb.test.DatabaseTestCase;
 import com.yahoo.squidb.test.ModelDependent;
+import com.yahoo.squidb.test.TestViewModel;
 
 public class ModelDependentSpecTest extends DatabaseTestCase {
 
@@ -20,4 +21,13 @@ public class ModelDependentSpecTest extends DatabaseTestCase {
         }
     }
 
+    public void testModelDependentConstantFromInnerClassIsAccessible() {
+        try {
+            TestViewModel.DEFAULT_ORDER.getClass();
+        } catch (ExceptionInInitializerError e) {
+            fail("The generated model must define constants that depend on other constants after " +
+                    "their dependencies. Fields marked `static final` are initialised in the order " +
+                    "they appear in the source.");
+        }
+    }
 }

--- a/squidb-tests/src/com/yahoo/squidb/test/TestViewModelSpec.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/TestViewModelSpec.java
@@ -5,9 +5,11 @@
  */
 package com.yahoo.squidb.test;
 
+import com.yahoo.squidb.annotations.Constants;
 import com.yahoo.squidb.annotations.ViewModelSpec;
 import com.yahoo.squidb.annotations.ViewQuery;
 import com.yahoo.squidb.sql.Function;
+import com.yahoo.squidb.sql.Order;
 import com.yahoo.squidb.sql.Property.LongProperty;
 import com.yahoo.squidb.sql.Property.StringProperty;
 import com.yahoo.squidb.sql.Query;
@@ -32,5 +34,10 @@ public class TestViewModelSpec {
 
     public static final StringProperty UPPERCASE_NAME = StringProperty
             .fromFunction(Function.upper(EMPLOYEE_NAME), "uppercase_name");
+
+    @Constants
+    public static class Const {
+        public static final Order DEFAULT_ORDER = TestViewModel.EMPLOYEE_MODEL_ID.asc();
+    }
 
 }


### PR DESCRIPTION
Most constants can safely be copied directly to the generated model. However, constants that are defined using table schema fields (e.g. from Properties, Table, View, like public static final Order DEFAULT_ORDER = Model.COLUMN.asc()) may run into class loading order issues where the fields needed to initialize the constant have not yet themselves been initialized at class loading time. (This is discussed in more detail in #110.

This commit allows constants to be declared in a static inner class of the model spec, effectively deferring initialization of copied constants until after the full schema has been initialized. The old behavior of directly copying constants has been left intact so those who don't need this control over class loading order can use things as they always have.