### PR TITLE
Criterion negation enhancements

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/sql/CriterionTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/CriterionTest.java
@@ -19,8 +19,11 @@ public class CriterionTest extends SquidTestCase {
         assertNegationEqualsTheOther(TestModel.LUCKY_NUMBER.gt(5), TestModel.LUCKY_NUMBER.lte(5));
         assertNegationEqualsTheOther(TestModel.LUCKY_NUMBER.gte(5), TestModel.LUCKY_NUMBER.lt(5));
         assertNegationEqualsTheOther(TestModel.FIRST_NAME.in(Collections.EMPTY_SET),
-                Criterion.not(TestModel.FIRST_NAME.in(Collections.EMPTY_SET)));
+                TestModel.FIRST_NAME.notIn(Collections.EMPTY_SET));
         assertNegationEqualsTheOther(TestModel.FIRST_NAME.isNull(), TestModel.FIRST_NAME.isNotNull());
+        assertNegationEqualsTheOther(TestModel.LUCKY_NUMBER.between(1, 2), TestModel.LUCKY_NUMBER.notBetween(1, 2));
+        assertNegationEqualsTheOther(TestModel.FIRST_NAME.like("A"), TestModel.FIRST_NAME.notLike("A"));
+        assertNegationEqualsTheOther(TestModel.FIRST_NAME.glob("A*"), TestModel.FIRST_NAME.notGlob("A*"));
     }
 
     private void assertNegationEqualsTheOther(Criterion c1, Criterion c2) {

--- a/squidb/src/com/yahoo/squidb/sql/BetweenCriterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/BetweenCriterion.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.sql;
+
+class BetweenCriterion extends BinaryCriterion {
+
+    private final Object lower;
+    private final Object upper;
+
+    BetweenCriterion(Field<?> expression, Operator operator, Object lower, Object upper) {
+        super(expression, operator, null);
+        this.lower = lower;
+        this.upper = upper;
+    }
+
+    @Override
+    protected void afterPopulateOperator(SqlBuilder builder, boolean forSqlValidation) {
+        builder.addValueToSql(lower, forSqlValidation);
+        builder.sql.append(" AND ");
+        builder.addValueToSql(upper, forSqlValidation);
+    }
+
+    @Override
+    protected BinaryCriterion constructNegatedCriterion(Operator negatedOperator) {
+        return new BetweenCriterion(field, negatedOperator, lower, upper);
+    }
+}

--- a/squidb/src/com/yahoo/squidb/sql/BinaryCriterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/BinaryCriterion.java
@@ -39,8 +39,12 @@ class BinaryCriterion extends Criterion {
     public Criterion negate() {
         Operator contrary = operator.getContrary();
         if (contrary != null) {
-            return new BinaryCriterion(field, contrary, value);
+            return constructNegatedCriterion(contrary);
         }
         return super.negate();
+    }
+
+    protected BinaryCriterion constructNegatedCriterion(Operator negatedOperator) {
+        return new BinaryCriterion(field, negatedOperator, value);
     }
 }

--- a/squidb/src/com/yahoo/squidb/sql/CaseInsensitiveEqualsCriterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/CaseInsensitiveEqualsCriterion.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.sql;
+
+class CaseInsensitiveEqualsCriterion extends BinaryCriterion {
+
+    CaseInsensitiveEqualsCriterion(Field<?> expression, Operator operator, Object value) {
+        super(expression, operator, value);
+    }
+
+    @Override
+    protected void afterPopulateOperator(SqlBuilder builder, boolean forSqlValidation) {
+        super.afterPopulateOperator(builder, forSqlValidation);
+        builder.sql.append(" COLLATE NOCASE ");
+    }
+
+    @Override
+    protected BinaryCriterion constructNegatedCriterion(Operator negatedOperator) {
+        return new CaseInsensitiveEqualsCriterion(field, negatedOperator, value);
+    }
+}

--- a/squidb/src/com/yahoo/squidb/sql/InCollectionCriterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/InCollectionCriterion.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.sql;
+
+import java.util.Collection;
+
+class InCollectionCriterion extends BinaryCriterion {
+
+    private final Collection<?> collection;
+
+    InCollectionCriterion(Field<?> expression, Operator operator, Collection<?> value) {
+        super(expression, operator, value);
+        this.collection = value;
+    }
+
+    @Override
+    protected void afterPopulateOperator(SqlBuilder builder, boolean forSqlValidation) {
+        builder.sql.append("(");
+        builder.addCollectionArg(collection);
+        builder.sql.append(")");
+    }
+
+    @Override
+    protected BinaryCriterion constructNegatedCriterion(Operator negatedOperator) {
+        return new InCollectionCriterion(field, negatedOperator, collection);
+    }
+}

--- a/squidb/src/com/yahoo/squidb/sql/LikeCriterion.java
+++ b/squidb/src/com/yahoo/squidb/sql/LikeCriterion.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.sql;
+
+class LikeCriterion extends BinaryCriterion {
+
+    private final char escape;
+
+    LikeCriterion(Field<?> expression, Operator operator, Object value, char escape) {
+        super(expression, operator, value);
+        this.escape = escape;
+    }
+
+    @Override
+    protected void afterPopulateOperator(SqlBuilder builder, boolean forSqlValidation) {
+        super.afterPopulateOperator(builder, forSqlValidation);
+        if (escape != '\0') {
+            builder.sql.append(" ESCAPE ").append(SqlUtils.sanitizeStringAsLiteral(Character.toString(escape)));
+        }
+    }
+
+    @Override
+    protected BinaryCriterion constructNegatedCriterion(Operator negatedOperator) {
+        return new LikeCriterion(field, negatedOperator, value, escape);
+    }
+}

--- a/squidb/src/com/yahoo/squidb/sql/Operator.java
+++ b/squidb/src/com/yahoo/squidb/sql/Operator.java
@@ -38,12 +38,20 @@ public enum Operator {
     exists(" EXISTS "),
     /** LIKE */
     like(" LIKE "),
+    /** NOT LIKE */
+    notLike(" NOT LIKE "),
     /** IN */
     in(" IN "),
+    /** NOT IN */
+    notIn(" NOT IN "),
     /** BETWEEN */
     between(" BETWEEN "),
+    /** NOT BETWEEN */
+    notBetween(" NOT BETWEEN "),
     /** GLOB */
     glob(" GLOB "),
+    /** NOT GLOB */
+    notGlob(" NOT GLOB "),
     /** MATCH */
     match(" MATCH ");
 
@@ -58,6 +66,14 @@ public enum Operator {
         contraryRegistry.put(lte, gt);
         contraryRegistry.put(lt, gte);
         contraryRegistry.put(gte, lt);
+        contraryRegistry.put(like, notLike);
+        contraryRegistry.put(notLike, like);
+        contraryRegistry.put(in, notIn);
+        contraryRegistry.put(notIn, in);
+        contraryRegistry.put(between, notBetween);
+        contraryRegistry.put(notBetween, between);
+        contraryRegistry.put(glob, notGlob);
+        contraryRegistry.put(notGlob, glob);
     }
 
     private final String operator;


### PR DESCRIPTION
Add explicit negation methods for many of the standard criterions. E.g. `in(...)` now has a `notIn(...)` counterpart, `like(...)` has `notLike(...)`, etc. Each of these criterions will also generate more readable SQL when negated. Refs #116.