### PR TITLE
Table aliasing bugfix

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/PropertyTest.java
@@ -13,6 +13,7 @@ import com.yahoo.squidb.sql.Property.IntegerProperty;
 import com.yahoo.squidb.sql.Property.LongProperty;
 import com.yahoo.squidb.sql.Property.StringProperty;
 import com.yahoo.squidb.sql.Query;
+import com.yahoo.squidb.sql.Table;
 import com.yahoo.squidb.test.SquidTestCase;
 import com.yahoo.squidb.test.TestModel;
 import com.yahoo.squidb.test.TestViewModel;
@@ -85,6 +86,12 @@ public class PropertyTest extends SquidTestCase {
 
         assertEquals(test5, test6);
         assertEquals(test5.hashCode(), test6.hashCode());
+    }
+
+    public void testAliasedTableHasIdProperty() {
+        Table testModelAlias = TestModel.TABLE.as("testModelAlias");
+        LongProperty testModelAliasId = testModelAlias.getIdProperty();
+        assertEquals("testModelAlias._id", testModelAliasId.getQualifiedExpression());
     }
 
     public void testLiteralProperties() {

--- a/squidb/src/com/yahoo/squidb/sql/Table.java
+++ b/squidb/src/com/yahoo/squidb/sql/Table.java
@@ -43,12 +43,16 @@ public class Table extends SqlTable<TableModel> {
     }
 
     public Table qualifiedFromDatabase(String databaseName) {
-        return new Table(modelClass, properties, getExpression(), databaseName, tableConstraint, alias);
+        Table result = new Table(modelClass, properties, getExpression(), databaseName, tableConstraint, alias);
+        result.idProperty = idProperty;
+        return result;
     }
 
     @Override
     public Table as(String newAlias) {
-        return new Table(modelClass, properties, getExpression(), qualifier, tableConstraint, newAlias);
+        Table result = new Table(modelClass, properties, getExpression(), qualifier, tableConstraint, newAlias);
+        result.idProperty = result.qualifyField(idProperty);
+        return result;
     }
 
     /**


### PR DESCRIPTION
Aliased tables should still have an ID property set, because otherwise getIdProperty() will complain. We noticed this issue when attempting to construct a viewmodel where the backing query used aliased tables.