### PR TITLE
Make it easy to copy/generate javadocs in generated model classes (3.0 only)

### DIFF
--- a/squidb-processor/build.gradle
+++ b/squidb-processor/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
 dependencies {
-    compile 'com.yahoo.squidb:apt-utils:1.0.0'
+    compile 'com.yahoo.squidb:apt-utils:1.0.1'
     compile project(':squidb-annotations')
 }
 

--- a/squidb-processor/src/com/yahoo/squidb/processor/ModelSpecProcessor.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/ModelSpecProcessor.java
@@ -80,7 +80,7 @@ public final class ModelSpecProcessor extends AbstractProcessor {
     public synchronized void init(ProcessingEnvironment env) {
         super.init(env);
 
-        utils = new AptUtils(env.getMessager(), env.getTypeUtils());
+        utils = new AptUtils(env.getMessager(), env.getTypeUtils(), env.getElementUtils());
         filer = env.getFiler();
 
         pluginEnv = new PluginEnvironment(utils, env.getOptions());

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/Plugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/Plugin.java
@@ -127,6 +127,16 @@ public class Plugin {
     }
 
     /**
+     * Called after emitting the package and imports but before beginning the class declaration. Plugin subclasses can
+     * use this method to emit documentation/other comments or annotations.
+     *
+     * @param writer a {@link JavaFileWriter} for writing to
+     */
+    public void beforeEmitClassDeclaration(JavaFileWriter writer) throws IOException {
+        // Stub for subclasses to override
+    }
+
+    /**
      * Called before emitting the static declaration for the given property. Plugin subclasses can generate arbitrary
      * code here, but most often it would be useful for annotating the generated field
      *

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginBundle.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginBundle.java
@@ -100,6 +100,17 @@ public class PluginBundle {
     }
 
     /**
+     * Calls {@link Plugin#beforeEmitClassDeclaration(JavaFileWriter)} on all the bundled plugins
+     */
+    public void beforeEmitClassDeclaration(JavaFileWriter writer) throws IOException {
+        for (Plugin plugin : plugins) {
+            if (plugin.hasChangesForModelSpec()) {
+                plugin.beforeEmitClassDeclaration(writer);
+            }
+        }
+    }
+
+    /**
      * Calls {@link Plugin#beforeEmitSchema(JavaFileWriter)} on all the bundled plugins
      */
     public void beforeEmitSchema(JavaFileWriter writer) throws IOException {

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
@@ -11,6 +11,7 @@ import com.yahoo.squidb.processor.plugins.defaults.AndroidModelPlugin;
 import com.yahoo.squidb.processor.plugins.defaults.ConstantCopyingPlugin;
 import com.yahoo.squidb.processor.plugins.defaults.ConstructorPlugin;
 import com.yahoo.squidb.processor.plugins.defaults.ImplementsPlugin;
+import com.yahoo.squidb.processor.plugins.defaults.JavadocPlugin;
 import com.yahoo.squidb.processor.plugins.defaults.ModelMethodPlugin;
 import com.yahoo.squidb.processor.plugins.defaults.properties.InheritedModelSpecFieldPlugin;
 import com.yahoo.squidb.processor.plugins.defaults.properties.TableModelSpecFieldPlugin;
@@ -93,6 +94,11 @@ public class PluginEnvironment {
     public static final String OPTIONS_DISABLE_DEFAULT_GETTERS_AND_SETTERS = "disableGettersAndSetters";
 
     /**
+     * Option for disabling javadoc copying
+     */
+    public static final String OPTIONS_DISABLE_JAVADOC_COPYING = "disableJavadoc";
+
+    /**
      * Option for generating models that have Android-specific features
      */
     public static final String OPTIONS_GENERATE_ANDROID_MODELS = "androidModels";
@@ -132,6 +138,9 @@ public class PluginEnvironment {
         }
         if (!hasOption(OPTIONS_DISABLE_DEFAULT_METHOD_HANDLING)) {
             normalPriorityPlugins.add(ModelMethodPlugin.class);
+        }
+        if (!hasOption(OPTIONS_DISABLE_JAVADOC_COPYING)) {
+            normalPriorityPlugins.add(JavadocPlugin.class);
         }
 
         // Can't disable these, but they can be overridden by user plugins with high priority

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ConstantCopyingPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ConstantCopyingPlugin.java
@@ -119,7 +119,8 @@ public class ConstantCopyingPlugin extends Plugin {
     }
 
     private void writeConstantField(JavaFileWriter writer, DeclaredTypeName containingClassName,
-            VariableElement constant) throws IOException{
+            VariableElement constant) throws IOException {
+        JavadocPlugin.writeJavadocFromElement(pluginEnv, writer, constant);
         writer.writeFieldDeclaration(
                 utils.getTypeNameFromTypeMirror(constant.asType()),
                 constant.getSimpleName().toString(),

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/JavadocPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/JavadocPlugin.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.processor.plugins.defaults;
+
+import com.yahoo.aptutils.utils.AptUtils;
+import com.yahoo.aptutils.writer.JavaFileWriter;
+import com.yahoo.squidb.processor.data.ModelSpec;
+import com.yahoo.squidb.processor.plugins.Plugin;
+import com.yahoo.squidb.processor.plugins.PluginEnvironment;
+import com.yahoo.squidb.processor.plugins.defaults.properties.generators.PropertyGenerator;
+
+import java.io.IOException;
+
+import javax.lang.model.element.Element;
+
+/**
+ * A plugin that controls copying javadocs from fields in the model spec to the corresponding properties in the
+ * generated class. Other plugins can use the
+ * {@link #writeJavadocFromElement(PluginEnvironment, JavaFileWriter, Element)} method to copy javadocs from other
+ * elements in the model spec (e.g. model methods, constants, etc.)
+ */
+public class JavadocPlugin extends Plugin {
+
+    public JavadocPlugin(ModelSpec<?> modelSpec, PluginEnvironment pluginEnv) {
+        super(modelSpec, pluginEnv);
+    }
+
+    @Override
+    public void beforeEmitClassDeclaration(JavaFileWriter writer) throws IOException {
+        String generatedJavadoc = " This class was generated from the model spec at "
+                + "{@link " + modelSpec.getModelSpecName() + "}";
+
+        String elementJavadoc = utils.getElements().getDocComment(modelSpec.getModelSpecElement());
+        if (!AptUtils.isEmpty(elementJavadoc)) {
+            generatedJavadoc = (generatedJavadoc + "\n <br/>\n" + elementJavadoc);
+        }
+        writer.writeJavadoc(generatedJavadoc);
+        writer.writeComment("Generated code -- do not modify!");
+    }
+
+    @Override
+    public void beforeEmitPropertyDeclaration(JavaFileWriter writer, PropertyGenerator propertyGenerator)
+            throws IOException {
+        writeJavadocFromElement(pluginEnv, writer, propertyGenerator.getField());
+    }
+
+    /**
+     * Helper method that other plugins can use to copy javadocs from an Element
+     */
+    public static void writeJavadocFromElement(PluginEnvironment pluginEnv, JavaFileWriter writer, Element element)
+            throws IOException {
+        if (!pluginEnv.hasOption(PluginEnvironment.OPTIONS_DISABLE_JAVADOC_COPYING)) {
+            writer.writeJavadoc(pluginEnv.getUtils().getElements().getDocComment(element));
+        }
+    }
+}

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ModelMethodPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ModelMethodPlugin.java
@@ -85,6 +85,7 @@ public class ModelMethodPlugin extends Plugin {
         if (!CoreTypes.VOID.equals(params.getReturnType())) {
             methodCall = methodCall.returnExpr();
         }
+        JavadocPlugin.writeJavadocFromElement(pluginEnv, writer, e);
         writer.beginMethodDefinition(params)
                 .writeStatement(methodCall)
                 .finishMethodDefinition();

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
@@ -80,6 +80,7 @@ public abstract class ModelFileWriter<T extends ModelSpec<?>> {
 
         emitPackage();
         emitImports();
+        plugins.beforeEmitClassDeclaration(writer);
         beginClassDeclaration();
 
         plugins.beforeEmitSchema(writer);
@@ -115,8 +116,6 @@ public abstract class ModelFileWriter<T extends ModelSpec<?>> {
     }
 
     private void beginClassDeclaration() throws IOException {
-        writer.writeComment("Generated code -- do not modify!");
-        writer.writeComment("This class was generated from the model spec at " + modelSpec.getModelSpecName());
         if (modelSpec.getModelSpecElement().getAnnotation(Deprecated.class) != null) {
             writer.writeAnnotation(CoreTypes.DEPRECATED);
         }

--- a/squidb-tests/src/com/yahoo/squidb/test/TestModelSpec.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/TestModelSpec.java
@@ -17,6 +17,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+/**
+ * Here's a test javadoc for a model spec. It should be copied to the generated model.
+ */
 @TableModelSpec(className = "TestModel", tableName = "testModels",
         tableConstraint = "UNIQUE (creationDate) ON CONFLICT REPLACE")
 @Implements(interfaceClasses = Runnable.class,
@@ -39,6 +42,17 @@ public class TestModelSpec {
     @ColumnSpec(constraints = "UNIQUE COLLATE NOCASE")
     String lastName;
 
+    /**
+     * Here's a super awesome javadoc I made for this field<br/>
+     * Oh look, it has multiple lines
+     * <br/><br/>
+     * It even has lists!
+     * <ul>
+     * <li>Item 1</li>
+     * <li>Item 2</li>
+     * <li>Item 3</li>
+     * </ul>
+     */
     @ColumnSpec(name = "creationDate")
     long birthday;
 
@@ -61,6 +75,11 @@ public class TestModelSpec {
         return instance.getFirstName() + " " + instance.getLastName();
     }
 
+    /**
+     * Returns the display name of the test model prefixed with the given prefix
+     *
+     * @param prefix the prefix to use
+     */
     @ModelMethod(name = "prefixedName")
     public static String getDisplayNameWithPrefix(TestModel instance, String prefix) {
         return prefix + " " + instance.getDisplayName();
@@ -81,6 +100,13 @@ public class TestModelSpec {
         return null;
     }
 
+    /**
+     * It would be pretty great if this static method had a javadoc too
+     *
+     * @param instance first TestModel instance
+     * @param anotherInstance another TestModel instance
+     * @return the literal String "Blah"
+     */
     public static String someStaticMethod(TestModel instance, TestModel anotherInstance) {
         return "Blah";
     }


### PR DESCRIPTION
Add a JavadocPlugin that can copy javadocs from fields/methods/model spec classes to their corresponding entities in the generated class.

This is against the 3.0 branch because we use some of the updated plugin APIs.