### PR TITLE
Locking enhancements

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
@@ -611,7 +611,7 @@ public class SquidDatabaseTest extends DatabaseTestCase {
     private void concurrencyStressTest(AtomicReference<Exception> exception) {
         try {
             Random r = new Random();
-            int numOperations = 50;
+            int numOperations = 100;
             Thing t = new Thing();
             for (int i = 0; i < numOperations; i++) {
                 int rand = r.nextInt(10);

--- a/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
@@ -152,8 +152,11 @@ public class SquidDatabaseTest extends DatabaseTestCase {
                 badDatabase.beginTransaction();
                 try {
                     badDatabase.acquireExclusiveLock();
-                } finally {
+                } catch (IllegalStateException e) {
+                    // Need to do this in the catch block rather than the finally block, because otherwise tearDown is
+                    // called before we have a chance to release the transaction lock
                     badDatabase.endTransaction();
+                    throw e;
                 }
             }
         }, IllegalStateException.class);

--- a/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
@@ -25,8 +25,10 @@ import com.yahoo.squidb.test.TestViewModel;
 import com.yahoo.squidb.test.Thing;
 import com.yahoo.squidb.utility.VersionCode;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -580,5 +582,65 @@ public class SquidDatabaseTest extends DatabaseTestCase {
         assertNull(aException.get());
         assertNull(bException.get());
         assertEquals(10000, database.countAll(Thing.class));
+    }
+
+    public void testConcurrencyStressTest() {
+        int numThreads = 20;
+        final AtomicReference<Exception> exception = new AtomicReference<Exception>();
+        List<Thread> workers = new ArrayList<Thread>();
+        for (int i = 0; i < numThreads; i++) {
+            Thread t = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    concurrencyStressTest(exception);
+                }
+            });
+            t.start();
+            workers.add(t);
+        }
+        for (Thread t : workers) {
+            try {
+                t.join();
+            } catch (Exception e) {
+                exception.set(e);
+            }
+        }
+        assertNull(exception.get());
+    }
+
+    private void concurrencyStressTest(AtomicReference<Exception> exception) {
+        try {
+            Random r = new Random();
+            int numOperations = 50;
+            Thing t = new Thing();
+            for (int i = 0; i < numOperations; i++) {
+                int rand = r.nextInt(10);
+                if (rand == 0) {
+                    database.close();
+                } else if (rand == 1) {
+                    database.clear();
+                } else if (rand == 2) {
+                    database.recreate();
+                } else if (rand == 3) {
+                    database.beginTransactionNonExclusive();
+                    try {
+                        for (int j = 0; j < 20; j++) {
+                            t.setFoo(Integer.toString(j))
+                                    .setBar(-j);
+                            database.createNew(t);
+                        }
+                        database.setTransactionSuccessful();
+                    } finally {
+                        database.endTransaction();
+                    }
+                } else {
+                    t.setFoo(Integer.toString(i))
+                            .setBar(-i);
+                    database.createNew(t);
+                }
+            }
+        } catch (Exception e) {
+            exception.set(e);
+        }
     }
 }

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -912,9 +912,9 @@ public abstract class SquidDatabase {
      */
     @Beta
     protected void acquireExclusiveLock() {
-        if (inTransaction()) {
-            throw new IllegalStateException(
-                    "Can't acquire an exclusive lock when the calling thread is in a transaction");
+        if (readWriteLock.getReadHoldCount() > 0) {
+            throw new IllegalStateException("Can't acquire an exclusive lock when the calling thread is in a "
+                    + "transaction or otherwise holds a non-exclusive lock");
         }
         readWriteLock.writeLock().lock();
     }

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -1341,10 +1341,8 @@ public abstract class SquidDatabase {
             acquireNonExclusiveLock();
             try {
                 synchronized (this) {
-                    if (sqliteVersion == null) {
-                        sqliteVersion = readSqliteVersionLocked(getDatabase());
-                    }
-                    toReturn = sqliteVersion;
+                    getDatabase(); // Opening the database will populate the sqliteVersion field
+                    return sqliteVersion;
                 }
             } finally {
                 releaseNonExclusiveLock();

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -361,13 +361,12 @@ public abstract class SquidDatabase {
     protected synchronized final SQLiteDatabaseWrapper getDatabase() {
         // If we get here, we should already have the non-exclusive lock
         if (database == null) {
-            openForWriting();
+            openForWritingLocked();
         }
         return database;
     }
 
-    // This method is only ever called from within getDatabase(), which is synchronized
-    private void openForWriting() {
+    private void openForWritingLocked() {
         if (helper == null) {
             helper = getOpenHelper(context, getName(), new OpenHelperDelegate(), getVersion());
         }

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -947,9 +947,9 @@ public abstract class SquidDatabase {
      */
     @Beta
     protected void acquireExclusiveLock() {
-        if (readWriteLock.getReadHoldCount() > 0) {
+        if (readWriteLock.getReadHoldCount() > 0 && readWriteLock.getWriteHoldCount() == 0) {
             throw new IllegalStateException("Can't acquire an exclusive lock when the calling thread is in a "
-                    + "transaction or otherwise holds a non-exclusive lock");
+                    + "transaction or otherwise holds a non-exclusive lock and not the exclusive lock");
         }
         readWriteLock.writeLock().lock();
     }

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -519,6 +519,13 @@ public abstract class SquidDatabase {
      * Close the database if it has been opened previously. This method acquires the exclusive lock before closing the
      * db -- it will block if other threads are in transactions. This method will throw an exception if called from
      * within a transaction.
+     * <p>
+     * It is not safe to call this method from within any of the database open or migration hooks (e.g.
+     * {@link #onUpgrade(SQLiteDatabaseWrapper, int, int)}, {@link #onOpen(SQLiteDatabaseWrapper)},
+     * {@link #onMigrationFailed(MigrationFailedException)}), etc.
+     * <p>
+     * WARNING: Any open database resources (e.g. cursors) will be invalid after calling this method. Do not call this
+     * method if any open cursors may be in use.
      */
     public final void close() {
         acquireExclusiveLock();
@@ -541,8 +548,12 @@ public abstract class SquidDatabase {
      * Clear all data in the database. This method acquires the exclusive lock before closing the db -- it will block
      * if other threads are in transactions. This method will throw an exception if called from within a transaction.
      * <p>
-     * WARNING: Any open database resources (e.g. Cursors) will be abruptly closed. Do not call this method if other
-     * threads may be accessing the database. The existing database file will be deleted and all data will be lost.
+     * It is not safe to call this method from within any of the database open or migration hooks (e.g.
+     * {@link #onUpgrade(SQLiteDatabaseWrapper, int, int)}, {@link #onOpen(SQLiteDatabaseWrapper)},
+     * {@link #onMigrationFailed(MigrationFailedException)}), etc.
+     * <p>
+     * WARNING: Any open database resources (e.g. cursors) will be invalid after calling this method. Do not call this
+     * method if any open cursors may be in use. The existing database file will be deleted and all data will be lost.
      */
     public final void clear() {
         acquireExclusiveLock();
@@ -561,10 +572,12 @@ public abstract class SquidDatabase {
      * <p>
      * If called from within the {@link #onUpgrade(SQLiteDatabaseWrapper, int, int)} or
      * {@link #onDowngrade(SQLiteDatabaseWrapper, int, int)} hooks, this method will abort the remainder of the
-     * migration and simply clear the database.
+     * migration and simply clear the database. This method is also safe to call from within
+     * {@link #onMigrationFailed(MigrationFailedException)}
      * <p>
-     * WARNING: Any open connections to the database will be abruptly closed. Do not call this method if other threads
-     * may be accessing the database.
+     * WARNING: Any open database resources (e.g. cursors) will be invalid after calling this method. Do not call this
+     * method if any open cursors may be in use. The existing database file will be deleted and all data will be lost,
+     * with a new empty database taking its place.
      *
      * @see #clear()
      */

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -95,6 +95,13 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *
  * By convention, the <code>fetch...</code> methods return a single model instance corresponding to the first record
  * found, or null if no records are found for that particular form of fetch.
+ * <p>
+ * When implementing your own database access methods in your SquidDatabase subclass, you should not use the object's
+ * monitor for locking (e.g. synchronized methods or synchronized(this) blocks) -- doing so may cause deadlocks under
+ * certain conditions. Most users will not need to worry about this and will be able to implement things in
+ * their SquidDatabase subclass without resorting to locking, as all SquidDatabase methods are thread-safe. If you
+ * really do need locking for some reason, use a different object's monitor, or use {@link #acquireExclusiveLock()} or
+ * {@link #acquireNonExclusiveLock()} to control access to the database connection itself.
  */
 public abstract class SquidDatabase {
 

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -497,9 +497,9 @@ public abstract class SquidDatabase {
     }
 
     /**
-     * Close the database if it has been opened previously. This method acquires the exclusive lock before closing the db
-     * -- it will block if other threads are in transactions. This method will throw an exception if called from within
-     * a transaction.
+     * Close the database if it has been opened previously. This method acquires the exclusive lock before closing the
+     * db -- it will block if other threads are in transactions. This method will throw an exception if called from
+     * within a transaction.
      */
     public final void close() {
         acquireExclusiveLock();
@@ -517,7 +517,8 @@ public abstract class SquidDatabase {
     }
 
     /**
-     * Clear all data in the database.
+     * Clear all data in the database. This method acquires the exclusive lock before closing the db -- it will block
+     * if other threads are in transactions. This method will throw an exception if called from within a transaction.
      * <p>
      * WARNING: Any open database resources (e.g. Cursors) will be abruptly closed. Do not call this method if other
      * threads may be accessing the database. The existing database file will be deleted and all data will be lost.
@@ -533,7 +534,9 @@ public abstract class SquidDatabase {
     }
 
     /**
-     * Clears the database and recreates an empty version of it.
+     * Clears the database and recreates an empty version of it. This method acquires the exclusive lock before closing
+     * the db -- it will block if other threads are in transactions. This method will throw an exception if called from
+     * within a transaction.
      * <p>
      * WARNING: Any open connections to the database will be abruptly closed. Do not call this method if other threads
      * may be accessing the database.
@@ -544,6 +547,7 @@ public abstract class SquidDatabase {
         if (isInMigration) {
             throw new RecreateDuringMigrationException();
         } else {
+            // TODO: This could deadlock if called after a bad migration, because the non-exclusive lock will already be held
             acquireExclusiveLock();
             try {
                 clear();


### PR DESCRIPTION
This PR allows methods like close(), clear(), and recreate() to be called more safely in a multi-threaded environment. Calling these methods now acquires the exclusive lock, so that any ongoing transactions can finish before the DB is closed. (Open cursors may still abruptly be closed, however).