### PR TITLE
More minor locking tweaks

### DIFF
--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -792,6 +792,7 @@ public abstract class SquidDatabase {
             getDatabase().beginTransaction();
             transactionSuccessState.get().beginTransaction();
         } catch (RuntimeException e) {
+            // Only release lock if begin xact was not successful
             releaseNonExclusiveLock();
             throw e;
         }
@@ -809,6 +810,7 @@ public abstract class SquidDatabase {
             getDatabase().beginTransactionNonExclusive();
             transactionSuccessState.get().beginTransaction();
         } catch (RuntimeException e) {
+            // Only release lock if begin xact was not successful
             releaseNonExclusiveLock();
             throw e;
         }
@@ -827,6 +829,7 @@ public abstract class SquidDatabase {
             getDatabase().beginTransactionWithListener(listener);
             transactionSuccessState.get().beginTransaction();
         } catch (RuntimeException e) {
+            // Only release lock if begin xact was not successful
             releaseNonExclusiveLock();
             throw e;
         }
@@ -845,6 +848,7 @@ public abstract class SquidDatabase {
             getDatabase().beginTransactionWithListenerNonExclusive(listener);
             transactionSuccessState.get().beginTransaction();
         } catch (RuntimeException e) {
+            // Only release lock if begin xact was not successful
             releaseNonExclusiveLock();
             throw e;
         }


### PR DESCRIPTION
Minor tweaks to be slightly more defensive when we acquire the non-exclusive lock for transactions. If anything goes wrong, we should release the lock before we throw the exception, so that users who are suppressing exceptions at least won't have any chance of deadlock.