### PR TITLE
Fix doclint errors when using java8

### DIFF
--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -199,11 +199,11 @@ public abstract class SquidDatabase {
      * foreign key support.
      *
      * This method may be called at different points in the database lifecycle depending on the environment. When using
-     * a custom SQLite build with the squidb-sqlite-bindings project, or when running on Android API >= 16, it is
+     * a custom SQLite build with the squidb-sqlite-bindings project, or when running on Android API &gt;= 16, it is
      * called before {@link #onTablesCreated(SQLiteDatabaseWrapper) onTablesCreated},
      * {@link #onUpgrade(SQLiteDatabaseWrapper, int, int) onUpgrade},
      * {@link #onDowngrade(SQLiteDatabaseWrapper, int, int) onDowngrade},
-     * and {@link #onOpen(SQLiteDatabaseWrapper) onOpen}. If it is running on stock Android SQLite and API < 16, it
+     * and {@link #onOpen(SQLiteDatabaseWrapper) onOpen}. If it is running on stock Android SQLite and API &lt; 16, it
      * is called immediately before onOpen but after the other callbacks. The discrepancy is because onConfigure was
      * only introduced as a callback in API 16, but the ordering should not matter much for most use cases.
      * <p>


### PR DESCRIPTION
When you compile Squidb from source using java 8, the javadoc task uses a really strict new doclint, which fails when non-HTML escaped greater than and less than characters are used (since it interprets them as HTML tags). This PR replaced them with proper HTML so that javadocs are generated properly with the strict doclint.

Weird, huh?