### PR TITLE
fix java8 doclint errors that prevent compilation

### DIFF
--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -199,11 +199,11 @@ public abstract class SquidDatabase {
      * foreign key support.
      *
      * This method may be called at different points in the database lifecycle depending on the environment. When using
-     * a custom SQLite build with the squidb-sqlite-bindings project, or when running on Android API >= 16, it is
+     * a custom SQLite build with the squidb-sqlite-bindings project, or when running on Android API &gt;= 16, it is
      * called before {@link #onTablesCreated(SQLiteDatabaseWrapper) onTablesCreated},
      * {@link #onUpgrade(SQLiteDatabaseWrapper, int, int) onUpgrade},
      * {@link #onDowngrade(SQLiteDatabaseWrapper, int, int) onDowngrade},
-     * and {@link #onOpen(SQLiteDatabaseWrapper) onOpen}. If it is running on stock Android SQLite and API < 16, it
+     * and {@link #onOpen(SQLiteDatabaseWrapper) onOpen}. If it is running on stock Android SQLite and API &lt; 16, it
      * is called immediately before onOpen but after the other callbacks. The discrepancy is because onConfigure was
      * only introduced as a callback in API 16, but the ordering should not matter much for most use cases.
      * <p>

--- a/squidb/src/com/yahoo/squidb/sql/Insert.java
+++ b/squidb/src/com/yahoo/squidb/sql/Insert.java
@@ -66,7 +66,7 @@ public class Insert extends TableStatement {
      * Specify a set of values to insert. The number of values must equal the number of columns specified and the order
      * must match the order of the columns.
      * <p>
-     * If you are using a SQLite version < 3.7.11 (Android API < 16 for stock SQLite), you should not call this method
+     * If you are using a SQLite version %lt; 3.7.11 (Android API %lt; 16 for stock SQLite), you should not call this method
      * more than once, as inserting multiple rows with a single statement is only supported for SQLite version 3.7.11
      * and higher. Calling this method more than once may cause an exception to be thrown when trying to execute the
      * statement.


### PR DESCRIPTION
In java8, doclint does not allow the use of "<" or ">" characters, and will fail compilation. This PR replaces the instances of those characters with HTML-friendly ones.