### PR TITLE
Open DB error handling

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/SquidDatabaseTest.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -99,9 +100,9 @@ public class SquidDatabaseTest extends DatabaseTestCase {
 
     private void testMigrationFailureCalled(boolean upgrade, boolean shouldThrow,
             boolean shouldRecreateDuringMigration, boolean shouldRecreateOnMigrationFailed) {
-        badDatabase.setShouldThrowDuringMigration(shouldThrow);
-        badDatabase.setShouldRecreateInMigration(shouldRecreateDuringMigration);
-        badDatabase.setShouldRecreateInOnMigrationFailed(shouldRecreateOnMigrationFailed);
+        badDatabase.shouldThrowDuringMigration = shouldThrow;
+        badDatabase.shouldRecreateInMigration = shouldRecreateDuringMigration;
+        badDatabase.shouldRecreateInOnMigrationFailed = shouldRecreateOnMigrationFailed;
 
         // set version manually
         SQLiteDatabaseWrapper db = badDatabase.getDatabase();
@@ -168,10 +169,10 @@ public class SquidDatabaseTest extends DatabaseTestCase {
     }
 
     public void testExceptionDuringOpenCleansUp() {
-        badDatabase.setShouldThrowDuringMigration(true);
-        badDatabase.setShouldRecreateInMigration(false);
-        badDatabase.setShouldRecreateInOnMigrationFailed(false);
-        badDatabase.setShouldRethrowInOnMigrationFailed(true);
+        badDatabase.shouldThrowDuringMigration = true;
+        badDatabase.shouldRecreateInMigration = true;
+        badDatabase.shouldRecreateInOnMigrationFailed = false;
+        badDatabase.shouldRethrowInOnMigrationFailed = true;
 
         testThrowsException(new Runnable() {
             @Override
@@ -240,6 +241,110 @@ public class SquidDatabaseTest extends DatabaseTestCase {
         }
     }
 
+    public void testRetryOpenDatabase() {
+        badDatabase.clear(); // init opens it, we need a new db
+        final AtomicBoolean openFailedHandlerCalled = new AtomicBoolean();
+        badDatabase.shouldThrowDuringOpen = true;
+        badDatabase.dbOpenFailedHandler = new DbOpenFailedHandler() {
+            @Override
+            public void dbOpenFailed(RuntimeException failure, int openFailureCount) {
+                openFailedHandlerCalled.set(true);
+                badDatabase.shouldThrowDuringOpen = false;
+                badDatabase.getDatabase();
+            }
+        };
+        badDatabase.getDatabase();
+        assertTrue(badDatabase.isOpen());
+        assertTrue(openFailedHandlerCalled.get());
+        assertEquals(1, badDatabase.dbOpenFailureCount);
+    }
+
+    public void testRecreateOnOpenFailed() {
+        final AtomicBoolean openFailedHandlerCalled = new AtomicBoolean();
+        badDatabase.persist(new Employee().setName("Alice"));
+        badDatabase.persist(new Employee().setName("Bob"));
+        badDatabase.persist(new Employee().setName("Cindy"));
+        assertEquals(3, badDatabase.countAll(Employee.class));
+
+        SQLiteDatabaseWrapper db = badDatabase.getDatabase();
+        db.setVersion(db.getVersion() + 1);
+        badDatabase.close();
+        badDatabase.shouldThrowDuringMigration = true;
+        badDatabase.shouldRethrowInOnMigrationFailed = true;
+        badDatabase.dbOpenFailedHandler = new DbOpenFailedHandler() {
+            @Override
+            public void dbOpenFailed(RuntimeException failure, int openFailureCount) {
+                openFailedHandlerCalled.set(true);
+                badDatabase.shouldThrowDuringOpen = false;
+                badDatabase.recreate();
+            }
+        };
+        badDatabase.getDatabase();
+        assertTrue(badDatabase.isOpen());
+        assertTrue(openFailedHandlerCalled.get());
+        assertEquals(1, badDatabase.dbOpenFailureCount);
+        assertEquals(0, badDatabase.countAll(Employee.class));
+    }
+
+    public void testSuppressingDbOpenFailedThrowsRuntimeException() {
+        badDatabase.clear();
+        final AtomicBoolean openFailedHandlerCalled = new AtomicBoolean();
+        badDatabase.shouldThrowDuringOpen = true;
+        badDatabase.dbOpenFailedHandler = new DbOpenFailedHandler() {
+            @Override
+            public void dbOpenFailed(RuntimeException failure, int openFailureCount) {
+                openFailedHandlerCalled.set(true);
+            }
+        };
+        testThrowsException(new Runnable() {
+            @Override
+            public void run() {
+                badDatabase.getDatabase();
+            }
+        }, RuntimeException.class);
+        assertTrue(openFailedHandlerCalled.get());
+        assertFalse(badDatabase.isOpen());
+    }
+
+    public void testRecursiveRetryDbOpen() {
+        testRecursiveRetryDbOpen(1, true);
+        testRecursiveRetryDbOpen(1, false);
+        testRecursiveRetryDbOpen(2, true);
+        testRecursiveRetryDbOpen(2, false);
+        testRecursiveRetryDbOpen(3, true);
+        testRecursiveRetryDbOpen(3, false);
+    }
+
+    private void testRecursiveRetryDbOpen(final int maxRetries, final boolean eventualRecovery) {
+        badDatabase.clear();
+        badDatabase.shouldThrowDuringOpen = true;
+        badDatabase.dbOpenFailedHandler = new DbOpenFailedHandler() {
+            @Override
+            public void dbOpenFailed(RuntimeException failure, int openFailureCount) {
+                if (openFailureCount >= maxRetries) {
+                    badDatabase.shouldThrowDuringOpen = false;
+                    if (!eventualRecovery) {
+                        throw failure;
+                    }
+                }
+                badDatabase.getDatabase();
+            }
+        };
+
+        if (eventualRecovery) {
+            badDatabase.getDatabase();
+        } else {
+            testThrowsException(new Runnable() {
+                @Override
+                public void run() {
+                    badDatabase.getDatabase();
+                }
+            }, RuntimeException.class);
+        }
+        assertEquals(maxRetries, badDatabase.dbOpenFailureCount);
+        assertEquals(eventualRecovery, badDatabase.isOpen());
+    }
+
     /**
      * {@link TestDatabase} that intentionally fails in onUpgrade and onDowngrade
      */
@@ -249,13 +354,16 @@ public class SquidDatabaseTest extends DatabaseTestCase {
         private boolean onUpgradeCalled = false;
         private boolean onDowngradeCalled = false;
         private boolean onTablesCreatedCalled = false;
+        private int dbOpenFailureCount = 0;
         private int migrationFailedOldVersion = 0;
         private int migrationFailedNewVersion = 0;
 
+        private boolean shouldThrowDuringOpen = false;
         private boolean shouldThrowDuringMigration = false;
         private boolean shouldRecreateInMigration = false;
         private boolean shouldRecreateInOnMigrationFailed = false;
         private boolean shouldRethrowInOnMigrationFailed = false;
+        private DbOpenFailedHandler dbOpenFailedHandler = null;
 
         public BadDatabase(Context context) {
             super(context);
@@ -274,6 +382,9 @@ public class SquidDatabaseTest extends DatabaseTestCase {
         @Override
         protected void onTablesCreated(SQLiteDatabaseWrapper db) {
             onTablesCreatedCalled = true;
+            if (shouldThrowDuringOpen) {
+                throw new RuntimeException("Simulating DB open failure");
+            }
         }
 
         @Override
@@ -310,26 +421,25 @@ public class SquidDatabaseTest extends DatabaseTestCase {
             }
         }
 
-        public void setShouldThrowDuringMigration(boolean flag) {
-            shouldThrowDuringMigration = flag;
-        }
-
-        public void setShouldRecreateInMigration(boolean flag) {
-            shouldRecreateInMigration = flag;
-        }
-
-        public void setShouldRecreateInOnMigrationFailed(boolean flag) {
-            shouldRecreateInOnMigrationFailed = flag;
-        }
-
-        public void setShouldRethrowInOnMigrationFailed(boolean flag) {
-            shouldRethrowInOnMigrationFailed = flag;
+        @Override
+        protected void onDatabaseOpenFailed(RuntimeException failure, int openFailureCount) {
+            dbOpenFailureCount = openFailureCount;
+            if (dbOpenFailedHandler != null) {
+                dbOpenFailedHandler.dbOpenFailed(failure, openFailureCount);
+            } else {
+                super.onDatabaseOpenFailed(failure, openFailureCount);
+            }
         }
 
         @Override
         protected boolean tryAddColumn(Property<?> property) {
             return super.tryAddColumn(property);
         }
+    }
+
+    private interface DbOpenFailedHandler {
+
+        void dbOpenFailed(RuntimeException failure, int openFailureCount);
     }
 
     public void testBasicInsertAndFetch() {

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -211,8 +211,9 @@ public abstract class SquidDatabase {
      * {@link SQLiteDatabaseWrapper#setVersion(int)} to reflect that you were able to recover and recover and complete
      * the migration successfully.
      * <p>
-     * Note that taking no action here leaves the database in whatever state it was in when the error occurred, which
-     * can result in unexpected errors if callers are allowed to invoke further operations on the database.
+     * You should not suppress this exception without attempting to reopen or recreate the database. If this method
+     * exits without throwing but the database is not open, another exception will be thrown that is likely to cause
+     * a crash.
      * <p>
      * Failures to open the database not caused by an error in the migration flow are handled by
      * the {@link #onDatabaseOpenFailed(RuntimeException, int)} hook.
@@ -224,8 +225,9 @@ public abstract class SquidDatabase {
     }
 
     /**
-     * Called if the database has failed to open for any reason other than a failure during a migration (which is
-     * handled by the {@link #onMigrationFailed(MigrationFailedException)} hook). Such occurrences should be rare;
+     * Called if the database has failed to open for any reason. Migration failures should be handled by the
+     * {@link #onMigrationFailed(MigrationFailedException)} hook, but if you do not override that method, migration
+     * failures will be forwarded to this hook instead. Non-migration failures that trigger this hook should be rare:
      * the result of programming errors, disk I/O failures, or corrupt databases. The default implementation of this
      * hook rethrows the exception, which will likely cause a crash. If you want to implement more sophisticated
      * failure handling, reasonable actions might be one or both of the following:

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -457,6 +457,12 @@ public abstract class SquidDatabase {
             databaseOpenFailedRetryCount++;
             try {
                 onDatabaseOpenFailed(e, retryCount);
+                // If this hook exits cleanly but the db still isn't open, the user probably did something bad in
+                // the hook, so we should clean up and rethrow
+                if (!isOpen()) {
+                    closeLocked();
+                    throw e;
+                }
             } finally {
                 databaseOpenFailedRetryCount = 0;
             }

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -167,11 +167,9 @@ public abstract class SquidDatabase {
      *
      * If this method returns false or throws an exception, a call to
      * {@link #onMigrationFailed(MigrationFailedException)} is triggered. The default implementation of
-     * onMigrationFailed throws an exception. It is highly recommended that you override onMigrationFailed to handle
-     * errors, either by calling {@link #recreate()} to delete all data in the database and start from scratch, or by
-     * manually searching for and correcting any problems in your database. If you do the latter, you should also
-     * be sure to finish by calling  {@link SQLiteDatabaseWrapper#setVersion(int)} to reflect that you were able to
-     * recover and complete the migration successfully.
+     * onMigrationFailed rethrows the exception. It is highly recommended that you override onMigrationFailed to handle
+     * errors, for example by calling {@link #recreate()} to delete all data in the database and start from scratch.
+     * More sophisticated recovery logic would require a different means of opening the database file.
      *
      * @param db the {@link SQLiteDatabaseWrapper} being upgraded
      * @param oldVersion the current database version
@@ -184,11 +182,10 @@ public abstract class SquidDatabase {
     /**
      * Called when the database should be downgraded from one version to another. If this method returns false or throws
      * an exception, a call to {@link #onMigrationFailed(MigrationFailedException)} is triggered. The default
-     * implementation of onMigrationFailed throws an exception. It is highly recommended that you override
-     * onMigrationFailed to handle errors, either by calling {@link #recreate()} to delete all data in the database and
-     * start from scratch, or by manually searching for and correcting any problems in your database. If you do the
-     * latter, you should also be sure to finish by calling {@link SQLiteDatabaseWrapper#setVersion(int)} to reflect
-     * that you were able to recover and complete the migration successfully.
+     * implementation of onMigrationFailed rethrows the exception. It is highly recommended that you override
+     * onMigrationFailed to handle errors, for example by calling {@link #recreate()} to delete all data in the
+     * database and start from scratch. More sophisticated recovery logic would require a different means of opening
+     * the database file.
      *
      * @param db the {@link SQLiteDatabaseWrapper} being upgraded
      * @param oldVersion the current database version
@@ -208,8 +205,8 @@ public abstract class SquidDatabase {
      * The default implementation of this method rethrows the MigrationFailedException parameter. Subclasses can take
      * drastic corrective action here, e.g. recreating the database with {@link #recreate()}. If instead of calling
      * recreate() you choose to take other corrective action, you should finish by calling
-     * {@link SQLiteDatabaseWrapper#setVersion(int)} to reflect that you were able to recover and recover and complete
-     * the migration successfully.
+     * {@link SQLiteDatabaseWrapper#setVersion(int)} to reflect that you were able to recover and complete the migration
+     * successfully.
      * <p>
      * You should not suppress this exception without attempting to reopen or recreate the database. If this method
      * exits without throwing but the database is not open, another exception will be thrown that is likely to cause
@@ -237,8 +234,6 @@ public abstract class SquidDatabase {
      * lest you risk stack overflows.</li>
      * <li>Call {@link #recreate()} to delete the database file and recreate an empty one</li>
      * </ul>
-     * Note that if you do not override {@link #onMigrationFailed(MigrationFailedException)}, any
-     * MigrationFailedExceptions will be forwarded to this hook as well.
      *
      * @param openFailureCount the number times this hook has been called, if you've called getDatabase() recursively.
      * The value will be 1 the first time this hook is called, 2 the second time, and so on.

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -443,6 +443,7 @@ public abstract class SquidDatabase {
                 }
             }
             if (!isOpen()) {
+                closeLocked();
                 throw new RuntimeException("Failed to open database");
             }
         } catch (RuntimeException e) {

--- a/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
+++ b/squidb/src/com/yahoo/squidb/data/SquidDatabase.java
@@ -240,11 +240,12 @@ public abstract class SquidDatabase {
      * Note that if you do not override {@link #onMigrationFailed(MigrationFailedException)}, any
      * MigrationFailedExceptions will be forwarded to this hook as well.
      *
-     * @param retryCount the number of tries to reopen the database so far, if you've called getDatabase() recursively
+     * @param openFailureCount the number times this hook has been called, if you've called getDatabase() recursively.
+     * The value will be 1 the first time this hook is called, 2 the second time, and so on.
      * @param failure the exception that caused opening the database to fail
      */
     @Beta
-    protected void onDatabaseOpenFailed(RuntimeException failure, int retryCount) {
+    protected void onDatabaseOpenFailed(RuntimeException failure, int openFailureCount) {
         throw failure;
     }
 
@@ -455,8 +456,7 @@ public abstract class SquidDatabase {
             // It would be invalid if the exception were suppressed accidentally
             closeLocked();
 
-            int retryCount = databaseOpenFailedRetryCount;
-            databaseOpenFailedRetryCount++;
+            int retryCount = ++databaseOpenFailedRetryCount;
             try {
                 onDatabaseOpenFailed(e, retryCount);
                 // If this hook exits cleanly but the db still isn't open, the user probably did something bad in


### PR DESCRIPTION
This PR adds an optional, overridable hook in SquidDatabase that allows the user to attempt to recover if the database fails to open for any reason (i.e., if we catch a RuntimeException trying to open the DB). There aren't too many actions that can be taken here, since the DB isn't open, so the hook is currently designed largely around the actions that are reasonable -- attempting to reopen the DB with a recursive call to `getDatabase()`, or deleting and recreating the DB using `recreate()`. A `retryCount` parameter incremented on each call to the hook allows clients to abort/crash instead of getting caught in an infinite loop if even deleting and recreating the DB file doesn't fix the problem. By default, if this hook is not overridden, it will simply rethrow whatever exception was forwarded to it (meaning if you don't use the new hook, behavior is exactly the same as it was before).

In future versions, we should consider if a checked exception approach would be better, but that would a) be a backwards-incompatible change and b) break from the Android pattern of preferring to throw RuntimeException subclasses for SQLite problems, so for now this seems like the safest option.

This PR is tagged with WIP so we can continue to consider the API and gather a bit of feedback before we merge it.