### PR TITLE
mapToModel fixes

### DIFF
--- a/squidb-addons/squidb-reactive/src/com/yahoo/squidb/reactive/ReactiveSquidDatabase.java
+++ b/squidb-addons/squidb-reactive/src/com/yahoo/squidb/reactive/ReactiveSquidDatabase.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import com.yahoo.squidb.data.AbstractModel;
 import com.yahoo.squidb.data.DataChangedNotifier;
 import com.yahoo.squidb.data.SquidDatabase;
+import com.yahoo.squidb.sql.Property;
 import com.yahoo.squidb.sql.SqlTable;
 
 import java.util.Collection;
@@ -57,6 +58,12 @@ public abstract class ReactiveSquidDatabase extends SquidDatabase {
     private static final Set<SqlTable<?>> INITIAL_TABLE = new HashSet<SqlTable<?>>();
     static {
         INITIAL_TABLE.add(new SqlTable<AbstractModel>(null, null, "<initial>") {
+            @Override
+            protected SqlTable<AbstractModel> asNewAliasWithPropertiesArray(String newAlias,
+                    Property<?>[] newProperties) {
+                throw new UnsupportedOperationException("Fake initial table for ReactiveSquidDatabase should never " +
+                        "be aliased");
+            }
         });
     }
 

--- a/squidb-processor/src/com/yahoo/squidb/processor/ModelSpecProcessor.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/ModelSpecProcessor.java
@@ -107,10 +107,9 @@ public final class ModelSpecProcessor extends AbstractProcessor {
                                 .printMessage(Kind.ERROR, "Unexpected element type " + element.getKind(), element);
                     }
                 }
-            }
-            else {
-                utils.getMessager()
-                        .printMessage(Kind.WARNING, "Skipping unsupported annotation received by processor: " + annotationType);
+            } else {
+                utils.getMessager().printMessage(Kind.WARNING,
+                        "Skipping unsupported annotation received by processor: " + annotationType);
             }
         }
 

--- a/squidb-tests/src/com/yahoo/squidb/data/ViewModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ViewModelTest.java
@@ -19,6 +19,9 @@ import com.yahoo.squidb.test.Thing;
 import com.yahoo.squidb.test.ThingJoin;
 import com.yahoo.squidb.test.ViewlessViewModel;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 @SuppressLint("DefaultLocale")
@@ -278,17 +281,48 @@ public class ViewModelTest extends DatabaseTestCase {
                 Thing readThing2 = thingJoin.mapToModel(new Thing(), ThingJoin.THING_2);
                 Thing readThing3 = thingJoin.mapToModel(new Thing(), ThingJoin.THING_3);
 
+                List<AbstractModel> allReadModels = thingJoin.mapToSourceModels();
+                assertEquals(3, allReadModels.size());
+
+                List<Thing> allReadThings = new ArrayList<Thing>(3);
+                for (AbstractModel model : allReadModels) {
+                    allReadThings.add((Thing) model);
+                }
+                // Sort by id
+                Collections.sort(allReadThings, new Comparator<Thing>() {
+                    @Override
+                    public int compare(Thing lhs, Thing rhs) {
+                        if (lhs.getId() == rhs.getId()) {
+                            return 0;
+                        } else if (lhs.getId() < rhs.getId()) {
+                            return -1;
+                        } else {
+                            return 1;
+                        }
+                    }
+                });
+
                 assertEquals(things[position].getId(), readThing1.getId());
-                assertEquals(things[position + 1].getId(), readThing2.getId());
-                assertEquals(things[position + 2].getId(), readThing3.getId());
-
                 assertEquals(things[position].getFoo(), readThing1.getFoo());
-                assertEquals(things[position + 1].getFoo(), readThing2.getFoo());
-                assertEquals(things[position + 2].getFoo(), readThing3.getFoo());
-
                 assertEquals(things[position].getBar(), readThing1.getBar());
+                assertEquals(allReadThings.get(0).getId(), readThing1.getId());
+                assertEquals(allReadThings.get(0).getFoo(), readThing1.getFoo());
+                assertEquals(allReadThings.get(0).getBar(), readThing1.getBar());
+
+                assertEquals(things[position + 1].getId(), readThing2.getId());
+                assertEquals(things[position + 1].getFoo(), readThing2.getFoo());
                 assertEquals(things[position + 1].getBar(), readThing2.getBar());
+                assertEquals(allReadThings.get(1).getId(), readThing2.getId());
+                assertEquals(allReadThings.get(1).getFoo(), readThing2.getFoo());
+                assertEquals(allReadThings.get(1).getBar(), readThing2.getBar());
+
+                assertEquals(things[position + 2].getId(), readThing3.getId());
+                assertEquals(things[position + 2].getFoo(), readThing3.getFoo());
                 assertEquals(things[position + 2].getBar(), readThing3.getBar());
+                assertEquals(allReadThings.get(2).getId(), readThing3.getId());
+                assertEquals(allReadThings.get(2).getFoo(), readThing3.getFoo());
+                assertEquals(allReadThings.get(2).getBar(), readThing3.getBar());
+
             }
         } finally {
             cursor.close();

--- a/squidb-tests/src/com/yahoo/squidb/data/ViewModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ViewModelTest.java
@@ -308,6 +308,8 @@ public class ViewModelTest extends DatabaseTestCase {
                 assertEquals(allReadThings.get(0).getId(), readThing1.getId());
                 assertEquals(allReadThings.get(0).getFoo(), readThing1.getFoo());
                 assertEquals(allReadThings.get(0).getBar(), readThing1.getBar());
+                assertEquals(things[position], readThing1);
+                assertEquals(allReadThings.get(0), readThing1);
 
                 assertEquals(things[position + 1].getId(), readThing2.getId());
                 assertEquals(things[position + 1].getFoo(), readThing2.getFoo());
@@ -315,6 +317,8 @@ public class ViewModelTest extends DatabaseTestCase {
                 assertEquals(allReadThings.get(1).getId(), readThing2.getId());
                 assertEquals(allReadThings.get(1).getFoo(), readThing2.getFoo());
                 assertEquals(allReadThings.get(1).getBar(), readThing2.getBar());
+                assertEquals(things[position + 1], readThing2);
+                assertEquals(allReadThings.get(1), readThing2);
 
                 assertEquals(things[position + 2].getId(), readThing3.getId());
                 assertEquals(things[position + 2].getFoo(), readThing3.getFoo());
@@ -322,6 +326,8 @@ public class ViewModelTest extends DatabaseTestCase {
                 assertEquals(allReadThings.get(2).getId(), readThing3.getId());
                 assertEquals(allReadThings.get(2).getFoo(), readThing3.getFoo());
                 assertEquals(allReadThings.get(2).getBar(), readThing3.getBar());
+                assertEquals(things[position + 2], readThing3);
+                assertEquals(allReadThings.get(2), readThing3);
 
             }
         } finally {

--- a/squidb-tests/src/com/yahoo/squidb/sql/PropertyTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/PropertyTest.java
@@ -88,11 +88,11 @@ public class PropertyTest extends DatabaseTestCase {
     }
 
     public void testAliasedTableAliasesAllProperties() {
-        Table testModelAlias = TestModel.TABLE.as("testModelAlias");
-        LongProperty testModelAliasId = testModelAlias.getIdProperty();
-        assertEquals("testModelAlias._id", testModelAliasId.getQualifiedExpression());
-
         testTableAndViewAliasing(TestModel.class, TestModel.TABLE);
+    }
+
+    public void testAliasedVirtualTableAliasesAllProperties() {
+        testTableAndViewAliasing(TestVirtualModel.class, TestVirtualModel.TABLE);
     }
 
     public void testAliasedViewAliasesAllProperties() {
@@ -103,9 +103,14 @@ public class PropertyTest extends DatabaseTestCase {
         testTableAndViewAliasing(TestSubqueryModel.class, TestSubqueryModel.SUBQUERY);
     }
 
-    private <T extends SqlTable<?>> void testTableAndViewAliasing(Class<? extends AbstractModel> modelClass,
-            T tableOrView) {
-        T testModelAlias = (T) tableOrView.as("testModelAlias");
+    private void testTableAndViewAliasing(Class<? extends AbstractModel> modelClass,
+            SqlTable<?> tableOrView) {
+        SqlTable<?> testModelAlias = tableOrView.as("testModelAlias");
+        if (testModelAlias instanceof Table) {
+            LongProperty testModelAliasId = ((Table) testModelAlias).getIdProperty();
+            String idName = testModelAlias instanceof VirtualTable ? "rowid" : "_id";
+            assertEquals("testModelAlias." + idName, testModelAliasId.getQualifiedExpression());
+        }
 
         Property<?>[] originalProperties = tableOrView.getProperties();
         Property<?>[] aliasedProperties = testModelAlias.getProperties();

--- a/squidb-tests/src/com/yahoo/squidb/sql/PropertyTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/PropertyTest.java
@@ -3,20 +3,18 @@
  * Copyrights licensed under the Apache 2.0 License.
  * See the accompanying LICENSE file for terms.
  */
-package com.yahoo.squidb.data;
+package com.yahoo.squidb.sql;
 
-import com.yahoo.squidb.sql.Function;
-import com.yahoo.squidb.sql.Property;
+import com.yahoo.squidb.data.AbstractModel;
+import com.yahoo.squidb.data.SquidCursor;
 import com.yahoo.squidb.sql.Property.BooleanProperty;
 import com.yahoo.squidb.sql.Property.DoubleProperty;
 import com.yahoo.squidb.sql.Property.IntegerProperty;
 import com.yahoo.squidb.sql.Property.LongProperty;
 import com.yahoo.squidb.sql.Property.StringProperty;
-import com.yahoo.squidb.sql.Query;
-import com.yahoo.squidb.sql.SqlTable;
-import com.yahoo.squidb.sql.Table;
 import com.yahoo.squidb.test.DatabaseTestCase;
 import com.yahoo.squidb.test.TestModel;
+import com.yahoo.squidb.test.TestSubqueryModel;
 import com.yahoo.squidb.test.TestViewModel;
 import com.yahoo.squidb.test.TestVirtualModel;
 import com.yahoo.squidb.test.Thing;
@@ -101,6 +99,10 @@ public class PropertyTest extends DatabaseTestCase {
         testTableAndViewAliasing(TestViewModel.class, TestViewModel.VIEW);
     }
 
+    public void testAliasedSubqueryAliasesAllProperties() {
+        testTableAndViewAliasing(TestSubqueryModel.class, TestSubqueryModel.SUBQUERY);
+    }
+
     private <T extends SqlTable<?>> void testTableAndViewAliasing(Class<? extends AbstractModel> modelClass,
             T tableOrView) {
         T testModelAlias = (T) tableOrView.as("testModelAlias");
@@ -123,7 +125,14 @@ public class PropertyTest extends DatabaseTestCase {
                 expectedSql.append(", ");
             }
         }
-        expectedSql.append(" FROM ").append(tableOrView.getName()).append(" AS testModelAlias");
+        expectedSql.append(" FROM ");
+        if (tableOrView instanceof SubqueryTable) {
+            expectedSql.append("(");
+            String compiledSql = ((SubqueryTable) tableOrView).query.compile(database.getSqliteVersion()).sql;
+            expectedSql.append(compiledSql).append(") AS testModelAlias");
+        } else {
+            expectedSql.append(tableOrView.getName()).append(" AS testModelAlias");
+        }
         assertEquals(expectedSql.toString(), query.compile(database.getSqliteVersion()).sql);
         SquidCursor<?> cursor = database.query(modelClass, query); // Test that this is valid SQL
         try {

--- a/squidb-tests/src/com/yahoo/squidb/test/ThingJoinSpec.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/ThingJoinSpec.java
@@ -1,0 +1,41 @@
+package com.yahoo.squidb.test;
+
+import com.yahoo.squidb.annotations.Constants;
+import com.yahoo.squidb.annotations.ViewModelSpec;
+import com.yahoo.squidb.annotations.ViewQuery;
+import com.yahoo.squidb.sql.Function;
+import com.yahoo.squidb.sql.Property;
+import com.yahoo.squidb.sql.Query;
+import com.yahoo.squidb.sql.Table;
+
+@ViewModelSpec(className = "ThingJoin", viewName = "thingJoin", isSubquery = true)
+public class ThingJoinSpec {
+
+    private static final Table THING_2 = Thing.TABLE.as("thing2");
+    private static final Table THING_3 = Thing.TABLE.as("thing3");
+
+    @ViewQuery
+    public static final Query QUERY = Query.select()
+            .from(Thing.TABLE)
+            .innerJoin(THING_2, Thing.ID.eq(Function.add(1, THING_2.qualifyField(Thing.ID))))
+            .innerJoin(THING_3, Thing.ID.eq(Function.add(2, THING_3.qualifyField(Thing.ID))));
+
+    public static final Property.LongProperty THING_1_ID = Thing.ID;
+    public static final Property.LongProperty THING_2_ID = THING_2.qualifyField(Thing.ID);
+    public static final Property.LongProperty THING_3_ID = THING_3.qualifyField(Thing.ID);
+
+    public static final Property.StringProperty THING_1_FOO = Thing.FOO;
+    public static final Property.StringProperty THING_2_FOO = THING_2.qualifyField(Thing.FOO);
+    public static final Property.StringProperty THING_3_FOO = THING_3.qualifyField(Thing.FOO);
+
+    public static final Property.IntegerProperty THING_1_BAR = Thing.BAR;
+    public static final Property.IntegerProperty THING_2_BAR = THING_2.qualifyField(Thing.BAR);
+    public static final Property.IntegerProperty THING_3_BAR = THING_3.qualifyField(Thing.BAR);
+
+    @Constants
+    public static class Const {
+        public static final Table THING_2 = ThingJoinSpec.THING_2;
+        public static final Table THING_3 = ThingJoinSpec.THING_3;
+    }
+
+}

--- a/squidb-tests/src/com/yahoo/squidb/test/ThingJoinSpec.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/ThingJoinSpec.java
@@ -17,8 +17,8 @@ public class ThingJoinSpec {
     @ViewQuery
     public static final Query QUERY = Query.select()
             .from(Thing.TABLE)
-            .innerJoin(THING_2, Thing.ID.eq(Function.add(1, THING_2.qualifyField(Thing.ID))))
-            .innerJoin(THING_3, Thing.ID.eq(Function.add(2, THING_3.qualifyField(Thing.ID))));
+            .innerJoin(THING_2, Thing.ID.eq(Function.subtract(THING_2.qualifyField(Thing.ID), 1)))
+            .innerJoin(THING_3, Thing.ID.eq(Function.subtract(THING_3.qualifyField(Thing.ID), 2)));
 
     public static final Property.LongProperty THING_1_ID = Thing.ID;
     public static final Property.LongProperty THING_2_ID = THING_2.qualifyField(Thing.ID);

--- a/squidb/src/com/yahoo/squidb/data/ViewModel.java
+++ b/squidb/src/com/yahoo/squidb/data/ViewModel.java
@@ -58,7 +58,7 @@ public abstract class ViewModel extends AbstractModel {
      * once without aliasing it, this would simply be e.g. Model.TABLE.
      * @return the destination model object
      */
-    public <T extends AbstractModel> T mapToModel(T dst, SqlTable<? extends T> tableAlias) {
+    public <T extends AbstractModel> T mapToModel(T dst, SqlTable<?> tableAlias) {
         TableMappingVisitors visitors = getTableMappingVisitors();
         if (visitors != null) {
             @SuppressWarnings("unchecked")

--- a/squidb/src/com/yahoo/squidb/data/ViewModel.java
+++ b/squidb/src/com/yahoo/squidb/data/ViewModel.java
@@ -211,7 +211,7 @@ public abstract class ViewModel extends AbstractModel {
     protected static class TableMappingVisitors {
 
         private Map<Class<? extends AbstractModel>, Map<SqlTable<?>, TableModelMappingVisitor<?>>> map =
-                new HashMap<Class<? extends AbstractModel>,Map<SqlTable<?>, TableModelMappingVisitor<?>>>();
+                new HashMap<Class<? extends AbstractModel>, Map<SqlTable<?>, TableModelMappingVisitor<?>>>();
 
         private <T extends AbstractModel> void put(Class<T> cls, SqlTable<?> table,
                 TableModelMappingVisitor<T> mapper) {

--- a/squidb/src/com/yahoo/squidb/data/ViewModel.java
+++ b/squidb/src/com/yahoo/squidb/data/ViewModel.java
@@ -232,7 +232,7 @@ public abstract class ViewModel extends AbstractModel {
                         return (TableModelMappingVisitor<T>) visitor;
                     }
                 } else {
-                    throw new UnsupportedOperationException("Attempted to mapToModel for class " + cls +
+                    throw new IllegalArgumentException("Attempted to mapToModel for class " + cls +
                             ", but multiple table aliases were found and none was specified. Use " +
                             "ViewModel.mapToModel(Class, SqlTable) with a non-null second argument");
                 }

--- a/squidb/src/com/yahoo/squidb/data/ViewModel.java
+++ b/squidb/src/com/yahoo/squidb/data/ViewModel.java
@@ -5,15 +5,12 @@
  */
 package com.yahoo.squidb.data;
 
-import android.util.Log;
-
 import com.yahoo.squidb.sql.Property;
 import com.yahoo.squidb.sql.Property.PropertyWritingVisitor;
 import com.yahoo.squidb.sql.Query;
 import com.yahoo.squidb.sql.SqlTable;
 import com.yahoo.squidb.sql.Table;
 import com.yahoo.squidb.sql.View;
-import com.yahoo.squidb.utility.SquidUtilities;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -235,11 +232,9 @@ public abstract class ViewModel extends AbstractModel {
                         return (TableModelMappingVisitor<T>) visitor;
                     }
                 } else {
-                    // Log an error and return null
-                    Log.e(SquidUtilities.LOG_TAG, "Attempted to mapToModel for class " + cls + ", but multiple" +
-                            " table aliases were found and none was specified. Use ViewModel.mapToModel(Class, " +
-                            "SqlTable) with a non-null second argument");
-                    return null;
+                    throw new UnsupportedOperationException("Attempted to mapToModel for class " + cls +
+                            ", but multiple table aliases were found and none was specified. Use " +
+                            "ViewModel.mapToModel(Class, SqlTable) with a non-null second argument");
                 }
             } else {
                 return (TableModelMappingVisitor<T>) visitors.get(table);

--- a/squidb/src/com/yahoo/squidb/sql/QueryTable.java
+++ b/squidb/src/com/yahoo/squidb/sql/QueryTable.java
@@ -14,8 +14,9 @@ abstract class QueryTable extends SqlTable<ViewModel> {
 
     final Query query;
 
-    protected QueryTable(Class<? extends ViewModel> modelClass, Property<?>[] properties, String name, Query query) {
-        super(modelClass, properties, name);
+    protected QueryTable(Class<? extends ViewModel> modelClass, Property<?>[] properties, String name,
+            String databaseName, Query query) {
+        super(modelClass, properties, name, databaseName);
         this.query = query;
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/SqlTable.java
+++ b/squidb/src/com/yahoo/squidb/sql/SqlTable.java
@@ -113,4 +113,18 @@ public abstract class SqlTable<T extends AbstractModel> extends DBObject<SqlTabl
         return properties;
     }
 
+    @Override
+    public SqlTable<T> as(String newAlias) {
+        Property<?>[] newProperties = properties == null ? null : new Property<?>[properties.length];
+        SqlTable<T> result = asNewAliasWithPropertiesArray(newAlias, newProperties);
+        if (newProperties != null) {
+            for (int i = 0; i < newProperties.length; i++) {
+                newProperties[i] = result.qualifyField(properties[i]);
+            }
+        }
+        return result;
+    }
+
+    protected abstract SqlTable<T> asNewAliasWithPropertiesArray(String newAlias, Property<?>[] newProperties);
+
 }

--- a/squidb/src/com/yahoo/squidb/sql/SubqueryTable.java
+++ b/squidb/src/com/yahoo/squidb/sql/SubqueryTable.java
@@ -42,6 +42,16 @@ public class SubqueryTable extends QueryTable {
     }
 
     @Override
+    public SubqueryTable as(String newAlias) {
+        return (SubqueryTable) super.as(newAlias);
+    }
+
+    @Override
+    protected SubqueryTable asNewAliasWithPropertiesArray(String newAlias, Property<?>[] newProperties) {
+        return new SubqueryTable(modelClass, newProperties, newAlias, query);
+    }
+
+    @Override
     void appendToSqlBuilder(SqlBuilder builder, boolean forSqlValidation) {
         builder.sql.append("(");
         query.appendToSqlBuilder(builder, forSqlValidation);

--- a/squidb/src/com/yahoo/squidb/sql/SubqueryTable.java
+++ b/squidb/src/com/yahoo/squidb/sql/SubqueryTable.java
@@ -13,7 +13,7 @@ import com.yahoo.squidb.data.ViewModel;
 public class SubqueryTable extends QueryTable {
 
     private SubqueryTable(Class<? extends ViewModel> modelClass, Property<?>[] properties, String name, Query query) {
-        super(modelClass, properties, name, query);
+        super(modelClass, properties, name, null, query);
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/sql/Table.java
+++ b/squidb/src/com/yahoo/squidb/sql/Table.java
@@ -50,8 +50,14 @@ public class Table extends SqlTable<TableModel> {
 
     @Override
     public Table as(String newAlias) {
-        Table result = new Table(modelClass, properties, getExpression(), qualifier, tableConstraint, newAlias);
-        result.idProperty = result.qualifyField(idProperty);
+        Property<?>[] newProperties = properties == null ? null : new Property<?>[properties.length];
+        Table result = new Table(modelClass, newProperties, getExpression(), qualifier, tableConstraint, newAlias);
+        if (newProperties != null) {
+            for (int i = 0; i < newProperties.length; i++) {
+                newProperties[i] = result.qualifyField(properties[i]);
+            }
+        }
+        result.idProperty = idProperty == null ? null : result.qualifyField(idProperty);
         return result;
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/Table.java
+++ b/squidb/src/com/yahoo/squidb/sql/Table.java
@@ -50,15 +50,14 @@ public class Table extends SqlTable<TableModel> {
 
     @Override
     public Table as(String newAlias) {
-        Property<?>[] newProperties = properties == null ? null : new Property<?>[properties.length];
-        Table result = new Table(modelClass, newProperties, getExpression(), qualifier, tableConstraint, newAlias);
-        if (newProperties != null) {
-            for (int i = 0; i < newProperties.length; i++) {
-                newProperties[i] = result.qualifyField(properties[i]);
-            }
-        }
+        Table result = (Table) super.as(newAlias);
         result.idProperty = idProperty == null ? null : result.qualifyField(idProperty);
         return result;
+    }
+
+    @Override
+    protected Table asNewAliasWithPropertiesArray(String newAlias, Property<?>[] newProperties) {
+        return new Table(modelClass, newProperties, getExpression(), qualifier, tableConstraint, newAlias);
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/sql/Table.java
+++ b/squidb/src/com/yahoo/squidb/sql/Table.java
@@ -19,7 +19,7 @@ import com.yahoo.squidb.utility.VersionCode;
 public class Table extends SqlTable<TableModel> {
 
     private final String tableConstraint;
-    private LongProperty idProperty;
+    protected LongProperty idProperty;
 
     public Table(Class<? extends TableModel> modelClass, Property<?>[] properties, String name) {
         this(modelClass, properties, name, null);

--- a/squidb/src/com/yahoo/squidb/sql/View.java
+++ b/squidb/src/com/yahoo/squidb/sql/View.java
@@ -15,9 +15,10 @@ public class View extends QueryTable {
 
     private boolean temporary;
 
-    private View(Class<? extends ViewModel> modelClass, Property<?>[] properties, String expression, String databaseName,
-            Query query, boolean temporary) {
+    private View(Class<? extends ViewModel> modelClass, Property<?>[] properties, String expression,
+            String databaseName, String alias, Query query, boolean temporary) {
         super(modelClass, properties, expression, databaseName, query);
+        this.alias = alias;
         this.temporary = temporary;
     }
 
@@ -42,7 +43,7 @@ public class View extends QueryTable {
      */
     public static View fromQuery(Query query, String name, Class<? extends ViewModel> modelClass,
             Property<?>[] properties) {
-        return new View(modelClass, properties, name, null, query, false);
+        return new View(modelClass, properties, name, null, null, query, false);
     }
 
     /**
@@ -66,11 +67,23 @@ public class View extends QueryTable {
      */
     public static View temporaryFromQuery(Query query, String name, Class<? extends ViewModel> modelClass,
             Property<?>[] properties) {
-        return new View(modelClass, properties, name, null, query, true);
+        return new View(modelClass, properties, name, null, null, query, true);
     }
 
     public View qualifiedFromDatabase(String databaseName) {
-        return new View(modelClass, properties, getExpression(), databaseName, query, temporary);
+        return new View(modelClass, properties, getExpression(), databaseName, alias, query, temporary);
+    }
+
+    @Override
+    public View as(String newAlias) {
+        Property<?>[] newProperties = properties == null ? null : new Property<?>[properties.length];
+        View result = new View(modelClass, newProperties, getExpression(), qualifier, newAlias, query, temporary);
+        if (newProperties != null) {
+            for (int i = 0; i < newProperties.length; i++) {
+                newProperties[i] = result.qualifyField(properties[i]);
+            }
+        }
+        return result;
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/sql/View.java
+++ b/squidb/src/com/yahoo/squidb/sql/View.java
@@ -15,9 +15,9 @@ public class View extends QueryTable {
 
     private boolean temporary;
 
-    private View(Class<? extends ViewModel> modelClass, Property<?>[] properties, String expression, Query query,
-            boolean temporary) {
-        super(modelClass, properties, expression, query);
+    private View(Class<? extends ViewModel> modelClass, Property<?>[] properties, String expression, String databaseName,
+            Query query, boolean temporary) {
+        super(modelClass, properties, expression, databaseName, query);
         this.temporary = temporary;
     }
 
@@ -42,7 +42,7 @@ public class View extends QueryTable {
      */
     public static View fromQuery(Query query, String name, Class<? extends ViewModel> modelClass,
             Property<?>[] properties) {
-        return new View(modelClass, properties, name, query, false);
+        return new View(modelClass, properties, name, null, query, false);
     }
 
     /**
@@ -66,7 +66,11 @@ public class View extends QueryTable {
      */
     public static View temporaryFromQuery(Query query, String name, Class<? extends ViewModel> modelClass,
             Property<?>[] properties) {
-        return new View(modelClass, properties, name, query, true);
+        return new View(modelClass, properties, name, null, query, true);
+    }
+
+    public View qualifiedFromDatabase(String databaseName) {
+        return new View(modelClass, properties, getExpression(), databaseName, query, temporary);
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/sql/View.java
+++ b/squidb/src/com/yahoo/squidb/sql/View.java
@@ -76,14 +76,12 @@ public class View extends QueryTable {
 
     @Override
     public View as(String newAlias) {
-        Property<?>[] newProperties = properties == null ? null : new Property<?>[properties.length];
-        View result = new View(modelClass, newProperties, getExpression(), qualifier, newAlias, query, temporary);
-        if (newProperties != null) {
-            for (int i = 0; i < newProperties.length; i++) {
-                newProperties[i] = result.qualifyField(properties[i]);
-            }
-        }
-        return result;
+        return (View) super.as(newAlias);
+    }
+
+    @Override
+    protected View asNewAliasWithPropertiesArray(String newAlias, Property<?>[] newProperties) {
+        return new View(modelClass, newProperties, getExpression(), qualifier, newAlias, query, temporary);
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/sql/VirtualTable.java
+++ b/squidb/src/com/yahoo/squidb/sql/VirtualTable.java
@@ -42,12 +42,19 @@ public class VirtualTable extends Table {
 
     @Override
     public VirtualTable qualifiedFromDatabase(String databaseName) {
-        return new VirtualTable(modelClass, properties, getExpression(), databaseName, moduleName, alias);
+        VirtualTable result = new VirtualTable(modelClass, properties, getExpression(), databaseName, moduleName, alias);
+        result.idProperty = idProperty;
+        return result;
     }
 
     @Override
     public VirtualTable as(String newAlias) {
-        return new VirtualTable(modelClass, properties, getExpression(), qualifier, moduleName, newAlias);
+        return (VirtualTable) super.as(newAlias);
+    }
+
+    @Override
+    protected VirtualTable asNewAliasWithPropertiesArray(String newAlias, Property<?>[] newProperties) {
+        return new VirtualTable(modelClass, newProperties, getExpression(), qualifier, moduleName, newAlias);
     }
 
     /**


### PR DESCRIPTION
ViewModel.mapToModel would break down when the view model was composed of multiple aliased joins on the same table. This PR adds a new version of the mapToModel method that takes an aliased table argument to correct this problem. The single-arg version will still work as expected if the view model joins on a table only once, but will throw an exception to indicate programmer error if it detects multiple aliases for the same class are present.