### PR TITLE
Fix handling of static final fields in model specs

### DIFF
--- a/squidb-processor/src/com/yahoo/squidb/processor/TypeConstants.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/TypeConstants.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Set;
 
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.VariableElement;
 
 public class TypeConstants {
 
@@ -23,6 +24,17 @@ public class TypeConstants {
             .asList(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL);
     public static final List<Modifier> PRIVATE_STATIC_FINAL = Arrays
             .asList(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL);
+    public static final List<Modifier> STATIC_FINAL = Arrays
+            .asList(Modifier.STATIC, Modifier.FINAL);
+
+    public static boolean isConstant(VariableElement field) {
+        Set<Modifier> modifiers = field.getModifiers();
+        return modifiers != null && modifiers.containsAll(STATIC_FINAL);
+    }
+
+    public static boolean isVisibleConstant(VariableElement field) {
+        return isConstant(field) && !field.getModifiers().contains(Modifier.PRIVATE);
+    }
 
     public static final String SQUIDB_PACKAGE = "com.yahoo.squidb";
     public static final String SQUIDB_SQL_PACKAGE = SQUIDB_PACKAGE + ".sql";

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ConstantCopyingPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ConstantCopyingPlugin.java
@@ -54,8 +54,7 @@ public class ConstantCopyingPlugin extends Plugin {
         if (field.getAnnotation(Deprecated.class) != null) {
             return false;
         }
-        Set<Modifier> modifiers = field.getModifiers();
-        if (modifiers.containsAll(TypeConstants.PUBLIC_STATIC_FINAL)) {
+        if (TypeConstants.isVisibleConstant(field)) {
             constantList.add(field);
             return true;
         }
@@ -119,7 +118,7 @@ public class ConstantCopyingPlugin extends Plugin {
     }
 
     private void writeConstantField(JavaFileWriter writer, DeclaredTypeName containingClassName,
-            VariableElement constant) throws IOException{
+            VariableElement constant) throws IOException {
         writer.writeFieldDeclaration(
                 utils.getTypeNameFromTypeMirror(constant.asType()),
                 constant.getSimpleName().toString(),

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/EnumFieldPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/EnumFieldPlugin.java
@@ -33,8 +33,8 @@ public class EnumFieldPlugin extends BaseFieldPlugin {
 
     @Override
     protected boolean hasPropertyGeneratorForField(VariableElement field, DeclaredTypeName fieldType) {
-        if (field.getModifiers().containsAll(TypeConstants.PUBLIC_STATIC_FINAL)) {
-            // Might be a constant, ignore
+        if (TypeConstants.isConstant(field)) {
+            // Looks like a constant, ignore
             return false;
         }
 

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/EnumFieldReferencePlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/EnumFieldReferencePlugin.java
@@ -36,7 +36,7 @@ public class EnumFieldReferencePlugin extends FieldReferencePlugin {
 
     @Override
     protected boolean hasPropertyGeneratorForField(VariableElement field, DeclaredTypeName fieldType) {
-        return field.getModifiers().containsAll(TypeConstants.PUBLIC_STATIC_FINAL)
+        return TypeConstants.isVisibleConstant(field)
                 && TypeConstants.ENUM_PROPERTY.equals(fieldType);
     }
 

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/FieldReferencePlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/FieldReferencePlugin.java
@@ -25,7 +25,7 @@ abstract class FieldReferencePlugin extends BaseFieldPlugin {
     @Override
     protected boolean hasPropertyGeneratorForField(VariableElement field, DeclaredTypeName fieldType) {
         return field.getAnnotation(Deprecated.class) == null
-                && field.getModifiers().containsAll(TypeConstants.PUBLIC_STATIC_FINAL)
+                && TypeConstants.isVisibleConstant(field)
                 && TypeConstants.isBasicPropertyType(fieldType);
     }
 

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/TableModelSpecFieldPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/TableModelSpecFieldPlugin.java
@@ -24,9 +24,7 @@ import com.yahoo.squidb.processor.plugins.defaults.properties.generators.Propert
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import javax.lang.model.element.Modifier;
 import javax.lang.model.element.VariableElement;
 import javax.tools.Diagnostic;
 import javax.tools.Diagnostic.Kind;
@@ -52,9 +50,8 @@ public class TableModelSpecFieldPlugin extends BaseFieldPlugin {
 
     @Override
     public boolean processVariableElement(VariableElement field, DeclaredTypeName fieldType) {
-        Set<Modifier> modifiers = field.getModifiers();
-        if (modifiers.containsAll(TypeConstants.PUBLIC_STATIC_FINAL)) {
-            // Might be a constant, ignore
+        if (TypeConstants.isConstant(field)) {
+            // Looks like a constant, ignore
             return false;
         } else {
             if (field.getAnnotation(PrimaryKey.class) != null) {

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/ViewModelSpecFieldPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/ViewModelSpecFieldPlugin.java
@@ -13,9 +13,6 @@ import com.yahoo.squidb.processor.data.ViewModelSpecWrapper;
 import com.yahoo.squidb.processor.plugins.PluginEnvironment;
 import com.yahoo.squidb.processor.plugins.defaults.properties.generators.PropertyGenerator;
 
-import java.util.Set;
-
-import javax.lang.model.element.Modifier;
 import javax.lang.model.element.VariableElement;
 import javax.tools.Diagnostic;
 
@@ -39,8 +36,7 @@ public class ViewModelSpecFieldPlugin extends FieldReferencePlugin {
     public boolean processVariableElement(VariableElement field, DeclaredTypeName fieldType) {
         boolean isViewProperty = TypeConstants.isBasicPropertyType(fieldType);
         ViewQuery isViewQuery = field.getAnnotation(ViewQuery.class);
-        Set<Modifier> modifiers = field.getModifiers();
-        if (modifiers.containsAll(TypeConstants.PUBLIC_STATIC_FINAL)) {
+        if (TypeConstants.isVisibleConstant(field)) {
             if (isViewQuery != null) {
                 if (!TypeConstants.QUERY.equals(fieldType)) {
                     utils.getMessager().printMessage(Diagnostic.Kind.ERROR,

--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -229,4 +229,8 @@ public class ModelTest extends DatabaseTestCase {
         TestModel fromDatabase = new TestModel(cursor);
         assertEquals(enumValue, fromDatabase.getSomeEnum());
     }
+
+    public void testNonPublicConstantCopying() {
+        assertEquals("somePackageProtectedConst", TestModel.PACKAGE_PROTECTED_CONST);
+    }
 }

--- a/squidb-tests/src/com/yahoo/squidb/test/TestModelSpec.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/TestModelSpec.java
@@ -32,6 +32,8 @@ public class TestModelSpec {
     public static final String STRING_CONST = "Hello";
     public static final Map<String, Property<?>> CONST_MAP = new HashMap<String, Property<?>>();
 
+    static final String PACKAGE_PROTECTED_CONST = "somePackageProtectedConst";
+
     @Deprecated
     public static final int DEPRECATED_CONST = -1;
 


### PR DESCRIPTION
There was a bug in the code generator that would create column definitions from private static final fields in model specs, since it only considered public static final fields to be constants. This fixes the bug, and also allows the constant copying plugin to copy any package-level or higher static final fields as constants to the generated model class.