### PR TITLE
Update for stable Android Studio 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 android:
   components:
     - tools
-    - build-tools-23.0.2
+    - build-tools-23.0.3
     - android-15
     - sys-img-armeabi-v7a-android-15
     - android-16

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/squidb-addons/squidb-jackson-plugin/build.gradle
+++ b/squidb-addons/squidb-jackson-plugin/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         if (gradle.gradleVersion.startsWith('2.2') || gradle.gradleVersion.startsWith('2.3')) {
             classpath 'com.github.dcendents:android-maven-plugin:1.2'
         } else {
@@ -33,7 +33,7 @@ dependencies {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     sourceSets {
         main {

--- a/squidb-addons/squidb-reactive/build.gradle
+++ b/squidb-addons/squidb-reactive/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         if (gradle.gradleVersion.startsWith('2.2') || gradle.gradleVersion.startsWith('2.3')) {
             classpath 'com.github.dcendents:android-maven-plugin:1.2'
         } else {
@@ -27,7 +27,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     sourceSets {
         main {

--- a/squidb-addons/squidb-recyclerview/build.gradle
+++ b/squidb-addons/squidb-recyclerview/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         if (gradle.gradleVersion.startsWith('2.2') || gradle.gradleVersion.startsWith('2.3')) {
             classpath 'com.github.dcendents:android-maven-plugin:1.2'
         } else {
@@ -27,7 +27,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     sourceSets {
         main {
@@ -51,7 +51,7 @@ android {
 
 dependencies {
     compile project(':squidb')
-    compile 'com.android.support:recyclerview-v7:23.2.1'
+    compile 'com.android.support:recyclerview-v7:23.3.0'
 }
 
 def siteUrl = 'https://github.com/yahoo/squidb'

--- a/squidb-addons/squidb-sqlite-bindings/build.gradle
+++ b/squidb-addons/squidb-sqlite-bindings/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         if (gradle.gradleVersion.startsWith('2.2') || gradle.gradleVersion.startsWith('2.3')) {
             classpath 'com.github.dcendents:android-maven-plugin:1.2'
         } else {
@@ -27,7 +27,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     sourceSets {
         main {

--- a/squidb-addons/squidb-support-loader/build.gradle
+++ b/squidb-addons/squidb-support-loader/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         if (gradle.gradleVersion.startsWith('2.2') || gradle.gradleVersion.startsWith('2.3')) {
             classpath 'com.github.dcendents:android-maven-plugin:1.2'
         } else {
@@ -27,7 +27,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     sourceSets {
         main {
@@ -51,7 +51,7 @@ android {
 
 dependencies {
     compile project(':squidb')
-    compile 'com.android.support:support-v4:23.2.1'
+    compile 'com.android.support:support-v4:23.3.0'
 }
 
 def siteUrl = 'https://github.com/yahoo/squidb'

--- a/squidb-sample/build.gradle
+++ b/squidb-sample/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }
@@ -19,7 +19,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.yahoo.squidb.sample"

--- a/squidb-tests/build.gradle
+++ b/squidb-tests/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }
@@ -19,7 +19,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     packagingOptions {
         exclude 'META-INF/ASL2.0'

--- a/squidb/build.gradle
+++ b/squidb/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         if (gradle.gradleVersion.startsWith('2.2') || gradle.gradleVersion.startsWith('2.3')) {
             classpath 'com.github.dcendents:android-maven-plugin:1.2'
         } else {
@@ -27,7 +27,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     sourceSets {
         main {


### PR DESCRIPTION
Bump gradle plugin, build tools, and support lib dependencies to the latest recommended by the stable Android Studio 2.0 release