### PR TITLE
Generate javadoc link back to model spec in generated model class (#163)

### DIFF
--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
@@ -132,7 +132,8 @@ public abstract class ModelFileWriter<T extends ModelSpec<?>> {
 
     private void beginClassDeclaration() throws IOException {
         writer.writeComment("Generated code -- do not modify!");
-        writer.writeComment("This class was generated from the model spec at " + modelSpec.getModelSpecName());
+        writer.writeString("/** This class was generated from the model spec at {@link "
+                + modelSpec.getModelSpecName() + "} */\n");
         if (modelSpec.getModelSpecElement().getAnnotation(Deprecated.class) != null) {
             writer.writeAnnotation(CoreTypes.DEPRECATED);
         }


### PR DESCRIPTION
Closes #163 