### PR TITLE
Fix spurious code gen warning

### DIFF
--- a/squidb-processor/src/com/yahoo/squidb/processor/data/ModelSpec.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/data/ModelSpec.java
@@ -79,7 +79,9 @@ public abstract class ModelSpec<T extends Annotation> {
                             "Element type " + typeName + " is not a concrete type, will be ignored", e);
                 } else if (!pluginBundle.processVariableElement((VariableElement) e, (DeclaredTypeName) typeName)) {
                     // Deprecated things are generally ignored by plugins, so don't warn about them
-                    if (e.getAnnotation(Deprecated.class) == null) {
+                    // private static final fields are generally internal model spec constants, so don't warn about them
+                    if (e.getAnnotation(Deprecated.class) == null &&
+                            !e.getModifiers().containsAll(TypeConstants.PRIVATE_STATIC_FINAL)) {
                         utils.getMessager().printMessage(Diagnostic.Kind.WARNING,
                                 "No plugin found to handle field", e);
                     }


### PR DESCRIPTION
Don't need to warn about private static final fields in model specs since they'd generally be internal constants.