### PR TITLE
Fix harmless warnings emitted by apt-utils in squidb-processor

### DIFF
--- a/squidb-addons/squidb-jackson-annotations/build.gradle
+++ b/squidb-addons/squidb-jackson-annotations/build.gradle
@@ -10,8 +10,8 @@ version = '2.0.3'
 apply plugin: 'java'
 apply plugin: 'maven'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 sourceSets {
     main {

--- a/squidb-addons/squidb-jackson-compiler/build.gradle
+++ b/squidb-addons/squidb-jackson-compiler/build.gradle
@@ -10,11 +10,10 @@ version = '2.0.3'
 apply plugin: 'java'
 apply plugin: 'maven'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 dependencies {
-    compile 'com.yahoo.squidb:apt-utils:1.0.0'
     compile project(':squidb-processor')
     compile project(':squidb-jackson-annotations')
 }

--- a/squidb-annotations/build.gradle
+++ b/squidb-annotations/build.gradle
@@ -10,8 +10,8 @@ version = '2.0.3'
 apply plugin: 'java'
 apply plugin: 'maven'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 sourceSets {
     main {

--- a/squidb-processor/build.gradle
+++ b/squidb-processor/build.gradle
@@ -10,11 +10,11 @@ version = '2.0.3'
 apply plugin: 'java'
 apply plugin: 'maven'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 dependencies {
-    compile 'com.yahoo.squidb:apt-utils:1.0.0'
+    compile 'com.yahoo.squidb:apt-utils:1.0.3'
     compile project(':squidb-annotations')
 }
 

--- a/squidb-processor/src/com/yahoo/squidb/processor/ModelSpecProcessor.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/ModelSpecProcessor.java
@@ -51,10 +51,10 @@ import javax.tools.Diagnostic.Kind;
  * }
  * </pre>
  */
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public final class ModelSpecProcessor extends AbstractProcessor {
 
-    private Set<String> supportedAnnotationTypes = new HashSet<String>();
+    private Set<String> supportedAnnotationTypes = new HashSet<>();
 
     private AptUtils utils;
     private Filer filer;
@@ -74,7 +74,7 @@ public final class ModelSpecProcessor extends AbstractProcessor {
 
     @Override
     public Set<String> getSupportedOptions() {
-        Set<String> supportedOptions = new HashSet<String>();
+        Set<String> supportedOptions = new HashSet<>();
         supportedOptions.add(PluginEnvironment.PLUGINS_KEY);
         supportedOptions.add(PluginEnvironment.OPTIONS_KEY);
         return supportedOptions;
@@ -84,7 +84,7 @@ public final class ModelSpecProcessor extends AbstractProcessor {
     public synchronized void init(ProcessingEnvironment env) {
         super.init(env);
 
-        utils = new AptUtils(env.getMessager(), env.getTypeUtils());
+        utils = new AptUtils(env);
         filer = env.getFiler();
 
         pluginEnv = new PluginEnvironment(utils, env.getOptions());

--- a/squidb-processor/src/com/yahoo/squidb/processor/TypeConstants.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/TypeConstants.java
@@ -91,7 +91,7 @@ public class TypeConstants {
         PROPERTY_VARARGS.setIsVarArgs(true);
     }
 
-    private static final Set<DeclaredTypeName> BASIC_PROPERTY_TYPES = new HashSet<DeclaredTypeName>();
+    private static final Set<DeclaredTypeName> BASIC_PROPERTY_TYPES = new HashSet<>();
 
     static {
         BASIC_PROPERTY_TYPES.add(TypeConstants.BLOB_PROPERTY);

--- a/squidb-processor/src/com/yahoo/squidb/processor/data/ModelSpec.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/data/ModelSpec.java
@@ -50,9 +50,9 @@ public abstract class ModelSpec<T extends Annotation> {
     protected final DeclaredTypeName modelSpecName;
     protected final TypeElement modelSpecElement;
 
-    private final List<PropertyGenerator> propertyGenerators = new ArrayList<PropertyGenerator>();
-    private final List<PropertyGenerator> deprecatedPropertyGenerators = new ArrayList<PropertyGenerator>();
-    private final Map<String, Object> metadataMap = new HashMap<String, Object>();
+    private final List<PropertyGenerator> propertyGenerators = new ArrayList<>();
+    private final List<PropertyGenerator> deprecatedPropertyGenerators = new ArrayList<>();
+    private final Map<String, Object> metadataMap = new HashMap<>();
 
     protected final AptUtils utils;
     protected final PluginBundle pluginBundle;
@@ -181,9 +181,9 @@ public abstract class ModelSpec<T extends Annotation> {
     /**
      * Attach arbitrary metadata to this model spec objects. Plugins can store metadata and then retrieve it later with
      * {@link #getMetadata(String)}
+     *
      * @param metadataKey key for storing/retrieving the metadata
      * @param metadata the metadata to store
-     *
      * @see #hasMetadata(String)
      * @see #getMetadata(String)
      */
@@ -194,7 +194,6 @@ public abstract class ModelSpec<T extends Annotation> {
     /**
      * @param metadataKey the metadata key to look up
      * @return true if there is metadata stored for the given key, false otherwise
-     *
      * @see #putMetadata(String, Object)
      * @see #getMetadata(String)
      */
@@ -204,9 +203,9 @@ public abstract class ModelSpec<T extends Annotation> {
 
     /**
      * Retrieve metadata that was previously attached with {@link #putMetadata(String, Object)}
+     *
      * @param metadataKey key for storing/retrieving metadata
      * @return the metadata object for the given key if one was found, null otherwise
-     *
      * @see #putMetadata(String, Object)
      * @see #hasMetadata(String)
      */

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
@@ -51,9 +51,9 @@ public class PluginEnvironment {
     private final AptUtils utils;
     private final Map<String, String> envOptions;
     private final Set<String> squidbOptions;
-    private List<Class<? extends Plugin>> highPriorityPlugins = new ArrayList<Class<? extends Plugin>>();
-    private List<Class<? extends Plugin>> normalPriorityPlugins = new ArrayList<Class<? extends Plugin>>();
-    private List<Class<? extends Plugin>> lowPriorityPlugins = new ArrayList<Class<? extends Plugin>>();
+    private List<Class<? extends Plugin>> highPriorityPlugins = new ArrayList<>();
+    private List<Class<? extends Plugin>> normalPriorityPlugins = new ArrayList<>();
+    private List<Class<? extends Plugin>> lowPriorityPlugins = new ArrayList<>();
 
     public enum PluginPriority {
         LOW,
@@ -110,7 +110,7 @@ public class PluginEnvironment {
     }
 
     private Set<String> parseOptions() {
-        Set<String> result = new HashSet<String>();
+        Set<String> result = new HashSet<>();
         String optionsString = envOptions.get(OPTIONS_KEY);
         if (!AptUtils.isEmpty(optionsString)) {
             String[] allOptions = optionsString.split(SEPARATOR);
@@ -240,7 +240,7 @@ public class PluginEnvironment {
      * @return a new {@link PluginBundle} containing Plugins initialized to handle the given model spec
      */
     public PluginBundle getPluginBundleForModelSpec(ModelSpec<?> modelSpec) {
-        List<Plugin> plugins = new ArrayList<Plugin>();
+        List<Plugin> plugins = new ArrayList<>();
         accumulatePlugins(plugins, highPriorityPlugins, modelSpec);
         accumulatePlugins(plugins, normalPriorityPlugins, modelSpec);
         accumulatePlugins(plugins, lowPriorityPlugins, modelSpec);

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ConstantCopyingPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ConstantCopyingPlugin.java
@@ -37,9 +37,8 @@ import javax.tools.Diagnostic;
  */
 public class ConstantCopyingPlugin extends Plugin {
 
-    private final List<VariableElement> constantElements = new ArrayList<VariableElement>();
-    private final Map<String, List<VariableElement>> innerClassConstants
-            = new HashMap<String, List<VariableElement>>();
+    private final List<VariableElement> constantElements = new ArrayList<>();
+    private final Map<String, List<VariableElement>> innerClassConstants = new HashMap<>();
 
     public ConstantCopyingPlugin(ModelSpec<?> modelSpec, PluginEnvironment pluginEnv) {
         super(modelSpec, pluginEnv);
@@ -74,7 +73,7 @@ public class ConstantCopyingPlugin extends Plugin {
                 }
 
                 TypeElement constantClass = (TypeElement) element;
-                List<VariableElement> constantList = new ArrayList<VariableElement>();
+                List<VariableElement> constantList = new ArrayList<>();
                 innerClassConstants.put(constantClass.getSimpleName().toString(), constantList);
 
                 for (Element e : constantClass.getEnclosedElements()) {

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ImplementsPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ImplementsPlugin.java
@@ -28,7 +28,7 @@ import javax.lang.model.element.TypeElement;
  */
 public class ImplementsPlugin extends Plugin {
 
-    private final List<DeclaredTypeName> interfaces = new ArrayList<DeclaredTypeName>();
+    private final List<DeclaredTypeName> interfaces = new ArrayList<>();
 
     public ImplementsPlugin(ModelSpec<?> modelSpec, PluginEnvironment pluginEnv) {
         super(modelSpec, pluginEnv);

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ModelMethodPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/ModelMethodPlugin.java
@@ -40,8 +40,8 @@ import javax.tools.Diagnostic;
  */
 public class ModelMethodPlugin extends Plugin {
 
-    private final List<ExecutableElement> modelMethods = new ArrayList<ExecutableElement>();
-    private final List<ExecutableElement> staticModelMethods = new ArrayList<ExecutableElement>();
+    private final List<ExecutableElement> modelMethods = new ArrayList<>();
+    private final List<ExecutableElement> staticModelMethods = new ArrayList<>();
 
     public ModelMethodPlugin(ModelSpec<?> modelSpec, PluginEnvironment pluginEnv) {
         super(modelSpec, pluginEnv);
@@ -69,7 +69,7 @@ public class ModelMethodPlugin extends Plugin {
         MethodDeclarationParameters params = utils.methodDeclarationParamsFromExecutableElement(e, modifiers);
 
         ModelMethod methodAnnotation = e.getAnnotation(ModelMethod.class);
-        List<Object> arguments = new ArrayList<Object>();
+        List<Object> arguments = new ArrayList<>();
         if (methodAnnotation != null) {
             String name = methodAnnotation.name();
             if (!AptUtils.isEmpty(name)) {

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/TableModelSpecFieldPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/TableModelSpecFieldPlugin.java
@@ -35,8 +35,7 @@ import javax.tools.Diagnostic.Kind;
  */
 public class TableModelSpecFieldPlugin extends BaseFieldPlugin {
 
-    private Map<DeclaredTypeName, Class<? extends PropertyGenerator>> generatorMap
-            = new HashMap<DeclaredTypeName, Class<? extends PropertyGenerator>>();
+    private Map<DeclaredTypeName, Class<? extends PropertyGenerator>> generatorMap = new HashMap<>();
 
     public TableModelSpecFieldPlugin(ModelSpec<?> modelSpec, PluginEnvironment pluginEnv) {
         super(modelSpec, pluginEnv);

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/BasicPropertyGenerator.java
@@ -100,7 +100,7 @@ public abstract class BasicPropertyGenerator extends PropertyGenerator {
 
     @Override
     public void emitPropertyDeclaration(JavaFileWriter writer) throws IOException {
-        List<String> constructorArgs = new ArrayList<String>();
+        List<String> constructorArgs = new ArrayList<>();
         constructorArgs.add(TableModelFileWriter.TABLE_NAME);
         constructorArgs.add("\"" + columnName + "\"");
         String columnDef = getColumnDefinition();
@@ -201,7 +201,7 @@ public abstract class BasicPropertyGenerator extends PropertyGenerator {
         }
 
         String methodToInvoke;
-        List<Object> arguments = new ArrayList<Object>();
+        List<Object> arguments = new ArrayList<>();
         arguments.add(Expressions.callMethodOn(propertyName, "getName"));
         if (ColumnSpec.DEFAULT_NULL.equals(defaultValue)) {
             methodToInvoke = "putNull";

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
@@ -51,7 +51,7 @@ public abstract class ModelFileWriter<T extends ModelSpec<?>> {
     private static final MethodDeclarationParameters GET_DEFAULT_VALUES_PARAMS;
 
     static {
-        List<TypeName> extend = new ArrayList<TypeName>();
+        List<TypeName> extend = new ArrayList<>();
         extend.add(TypeConstants.ABSTRACT_MODEL);
         GenericName returnGeneric = new GenericName(GenericName.WILDCARD_CHAR, extend, null);
         DeclaredTypeName returnType = TypeConstants.CREATOR.clone();
@@ -123,7 +123,7 @@ public abstract class ModelFileWriter<T extends ModelSpec<?>> {
     }
 
     private void emitImports() throws IOException {
-        Set<DeclaredTypeName> imports = new HashSet<DeclaredTypeName>();
+        Set<DeclaredTypeName> imports = new HashSet<>();
         modelSpec.addRequiredImports(imports);
         writer.writeImports(imports);
         writer.registerOtherKnownNames(TypeConstants.CREATOR, TypeConstants.MODEL_CREATOR,
@@ -147,7 +147,7 @@ public abstract class ModelFileWriter<T extends ModelSpec<?>> {
     }
 
     private List<DeclaredTypeName> accumulateInterfacesFromPlugins() {
-        Set<DeclaredTypeName> interfaces = new LinkedHashSet<DeclaredTypeName>();
+        Set<DeclaredTypeName> interfaces = new LinkedHashSet<>();
         modelSpec.getPluginBundle().addInterfacesToImplement(interfaces);
         return Arrays.asList(interfaces.toArray(new DeclaredTypeName[interfaces.size()]));
     }

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
@@ -41,7 +41,7 @@ public class TableModelFileWriter extends ModelFileWriter<TableModelSpecWrapper>
 
     private void emitTableDeclaration() throws IOException {
         writer.writeComment("--- table declaration");
-        List<Object> arguments = new ArrayList<Object>();
+        List<Object> arguments = new ArrayList<>();
         arguments.add(Expressions.classObject(modelSpec.getGeneratedClassName())); // modelClass
         arguments.add(PROPERTIES_ARRAY_NAME); // properties
         arguments.add("\"" + modelSpec.getSpecAnnotation().tableName() + "\""); // name


### PR DESCRIPTION
Update squidb-processor to use java 1.7 and the latest version of apt-utils, which removes several unecessary warnings