### PR TITLE
Move versions to root build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,11 @@ allprojects {
     }
 }
 
+subprojects {
+    group = 'com.yahoo.squidb'
+    version = '2.0.3'
+}
+
 if (JavaVersion.current().isJava8Compatible()) {
     allprojects {
         tasks.withType(Javadoc) {

--- a/squidb-addons/squidb-jackson-annotations/build.gradle
+++ b/squidb-addons/squidb-jackson-annotations/build.gradle
@@ -3,10 +3,6 @@
  * Copyrights licensed under the Apache 2.0 License.
  * See the accompanying LICENSE file for terms.
  */
-project.ext.artifactId = 'squidb-jackson-annotations'
-group = 'com.yahoo.squidb'
-version = '2.0.3'
-
 apply plugin: 'java'
 apply plugin: 'maven'
 

--- a/squidb-addons/squidb-jackson-compiler/build.gradle
+++ b/squidb-addons/squidb-jackson-compiler/build.gradle
@@ -3,10 +3,6 @@
  * Copyrights licensed under the Apache 2.0 License.
  * See the accompanying LICENSE file for terms.
  */
-project.ext.artifactId = 'squidb-jackson-compiler'
-group = 'com.yahoo.squidb'
-version = '2.0.3'
-
 apply plugin: 'java'
 apply plugin: 'maven'
 

--- a/squidb-addons/squidb-jackson-plugin/build.gradle
+++ b/squidb-addons/squidb-jackson-plugin/build.gradle
@@ -3,10 +3,6 @@
  * Copyrights licensed under the Apache 2.0 License.
  * See the accompanying LICENSE file for terms.
  */
-project.ext.artifactId = 'squidb-jackson-plugin'
-group = 'com.yahoo.squidb'
-version = '2.0.3'
-
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 

--- a/squidb-addons/squidb-reactive/build.gradle
+++ b/squidb-addons/squidb-reactive/build.gradle
@@ -3,10 +3,6 @@
  * Copyrights licensed under the Apache 2.0 License.
  * See the accompanying LICENSE file for terms.
  */
-project.ext.artifactId = 'squidb-reactive'
-group = 'com.yahoo.squidb'
-version = '2.0.3'
-
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 

--- a/squidb-addons/squidb-recyclerview/build.gradle
+++ b/squidb-addons/squidb-recyclerview/build.gradle
@@ -3,10 +3,6 @@
  * Copyrights licensed under the Apache 2.0 License.
  * See the accompanying LICENSE file for terms.
  */
-project.ext.artifactId = 'squidb-recyclerview'
-group = 'com.yahoo.squidb'
-version = '2.0.3'
-
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 

--- a/squidb-addons/squidb-sqlite-bindings/build.gradle
+++ b/squidb-addons/squidb-sqlite-bindings/build.gradle
@@ -3,10 +3,6 @@
  * Copyrights licensed under the Apache 2.0 License.
  * See the accompanying LICENSE file for terms.
  */
-project.ext.artifactId = 'squidb-sqlite-bindings'
-group = 'com.yahoo.squidb'
-version = '2.0.3'
-
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 

--- a/squidb-addons/squidb-support-loader/build.gradle
+++ b/squidb-addons/squidb-support-loader/build.gradle
@@ -3,10 +3,6 @@
  * Copyrights licensed under the Apache 2.0 License.
  * See the accompanying LICENSE file for terms.
  */
-project.ext.artifactId = 'squidb-support-loader'
-group = 'com.yahoo.squidb'
-version = '2.0.3'
-
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 

--- a/squidb-annotations/build.gradle
+++ b/squidb-annotations/build.gradle
@@ -3,10 +3,6 @@
  * Copyrights licensed under the Apache 2.0 License.
  * See the accompanying LICENSE file for terms.
  */
-project.ext.artifactId = 'squidb-annotations'
-group = 'com.yahoo.squidb'
-version = '2.0.3'
-
 apply plugin: 'java'
 apply plugin: 'maven'
 

--- a/squidb-processor/build.gradle
+++ b/squidb-processor/build.gradle
@@ -3,10 +3,6 @@
  * Copyrights licensed under the Apache 2.0 License.
  * See the accompanying LICENSE file for terms.
  */
-project.ext.artifactId = 'squidb-processor'
-group = 'com.yahoo.squidb'
-version = '2.0.3'
-
 apply plugin: 'java'
 apply plugin: 'maven'
 

--- a/squidb-sample/build.gradle
+++ b/squidb-sample/build.gradle
@@ -26,7 +26,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':squidb')
     compile project(':squidb-annotations')
     apt project(':squidb-processor')

--- a/squidb/build.gradle
+++ b/squidb/build.gradle
@@ -3,10 +3,6 @@
  * Copyrights licensed under the Apache 2.0 License.
  * See the accompanying LICENSE file for terms.
  */
-project.ext.artifactId = 'squidb'
-group = 'com.yahoo.squidb'
-version = '2.0.3'
-
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 


### PR DESCRIPTION
@sbosley Moving duplicated version to root.

version and group need to only be specified once at the root and `project.ext.artifactId` is not used.