### PR TITLE
Plugin options handling

### DIFF
--- a/samples/squidb-android-sample/build.gradle
+++ b/samples/squidb-android-sample/build.gradle
@@ -32,9 +32,3 @@ dependencies {
     compile project(':squidb-sample-core')
     apt project(':squidb-processor')
 }
-
-apt {
-    arguments {
-        squidbOptions 'androidModels'
-    }
-}

--- a/samples/squidb-android-sample/src/main/java/com/yahoo/squidb/sample/HelloSquiDBApplication.java
+++ b/samples/squidb-android-sample/src/main/java/com/yahoo/squidb/sample/HelloSquiDBApplication.java
@@ -37,7 +37,7 @@ public class HelloSquiDBApplication extends Application {
                 return new AndroidOpenHelper(HelloSquiDBApplication.this, databaseName, delegate, version);
             }
         });
-        TasksDatabase.getInstance().registerDataChangedNotifier(new UriNotifier(this.getContentResolver(), Task.TABLE) {
+        TasksDatabase.getInstance().registerDataChangedNotifier(new UriNotifier(getContentResolver(), Task.TABLE) {
             @Override
             protected boolean accumulateNotificationObjects(Set<Uri> accumulatorSet, SqlTable<?> table,
                     SquidDatabase database, DBOperation operation, AbstractModel modelValues, long rowId) {

--- a/samples/squidb-sample-core/build.gradle
+++ b/samples/squidb-sample-core/build.gradle
@@ -30,4 +30,24 @@ dependencies {
     compile project(':squidb')
     compile project(':squidb-annotations')
     apt project(':squidb-processor')
+
+    if (!generateIOSModels()) {
+        compile project(':squidb-android')
+    }
+}
+
+def generateIOSModels() {
+    // this environment variable is set by the Settings.xcconfig for IOS builds
+    !"$System.env.SQUIDB_IOS_SRC".isEmpty() && System.env.SQUIDB_IOS_SRC != null;
+}
+
+String squidbOptionsString = ''
+if (!generateIOSModels()) {
+    squidbOptionsString += 'androidModels'
+}
+
+apt {
+    arguments {
+        squidbOptions squidbOptionsString
+    }
 }

--- a/squidb-processor/src/com/yahoo/squidb/processor/ModelSpecProcessor.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/ModelSpecProcessor.java
@@ -16,6 +16,7 @@ import com.yahoo.squidb.processor.writers.TableModelFileWriter;
 import com.yahoo.squidb.processor.writers.ViewModelFileWriter;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -74,7 +75,8 @@ public final class ModelSpecProcessor extends AbstractProcessor {
         Set<String> supportedOptions = new HashSet<>();
         supportedOptions.add(PluginEnvironment.PLUGINS_KEY);
         supportedOptions.add(PluginEnvironment.OPTIONS_KEY);
-        return supportedOptions;
+        supportedOptions.addAll(pluginEnv.getPluginSupportedOptions());
+        return Collections.unmodifiableSet(supportedOptions);
     }
 
     @Override

--- a/squidb-processor/src/com/yahoo/squidb/processor/data/ModelSpec.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/data/ModelSpec.java
@@ -76,7 +76,7 @@ public abstract class ModelSpec<T extends Annotation> {
         this.modelSpecAnnotation = modelSpecElement.getAnnotation(modelSpecClass);
         this.generatedClassName = new DeclaredTypeName(modelSpecName.getPackageName(), getGeneratedClassNameString());
         this.pluginBundle = pluginEnv.getPluginBundleForModelSpec(this);
-        this.androidModels = pluginEnv.hasOption(PluginEnvironment.OPTIONS_GENERATE_ANDROID_MODELS);
+        this.androidModels = pluginEnv.hasSquidbOption(PluginEnvironment.OPTIONS_GENERATE_ANDROID_MODELS);
 
         processVariableElements();
         pluginBundle.afterProcessVariableElements();

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
@@ -274,10 +274,19 @@ public class PluginEnvironment {
         Set<String> unsupportedOptions = new HashSet<>(squidbOptions);
         unsupportedOptions.removeAll(SQUIDB_SUPPORTED_OPTIONS);
 
-        if (!AptUtils.isEmpty(unsupportedOptions)) {
-            String message = String.format(UNSUPPORTED_OPTIONS_WARNING, String.join(SEPARATOR, unsupportedOptions));
-            utils.getMessager().printMessage(Diagnostic.Kind.WARNING, message);
+        if (AptUtils.isEmpty(unsupportedOptions)) {
+            return;
         }
+
+        StringBuilder sb = new StringBuilder();
+        for (String option : unsupportedOptions) {
+            if (sb.length() > 0) {
+                sb.append(SEPARATOR);
+            }
+            sb.append(option);
+        }
+        String message = String.format(UNSUPPORTED_OPTIONS_WARNING, sb);
+        utils.getMessager().printMessage(Diagnostic.Kind.WARNING, message);
     }
 
     /**

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
@@ -162,20 +162,20 @@ public class PluginEnvironment {
     }
 
     private void initializeDefaultPlugins() {
-        if (hasOption(OPTIONS_GENERATE_ANDROID_MODELS)) {
+        if (hasSquidbOption(OPTIONS_GENERATE_ANDROID_MODELS)) {
             normalPriorityPlugins.add(AndroidModelPlugin.class);
         }
 
-        if (!hasOption(OPTIONS_DISABLE_DEFAULT_CONSTRUCTORS)) {
+        if (!hasSquidbOption(OPTIONS_DISABLE_DEFAULT_CONSTRUCTORS)) {
             normalPriorityPlugins.add(ConstructorPlugin.class);
         }
-        if (!hasOption(OPTIONS_DISABLE_DEFAULT_IMPLEMENTS_HANDLING)) {
+        if (!hasSquidbOption(OPTIONS_DISABLE_DEFAULT_IMPLEMENTS_HANDLING)) {
             normalPriorityPlugins.add(ImplementsPlugin.class);
         }
-        if (!hasOption(OPTIONS_DISABLE_DEFAULT_METHOD_HANDLING)) {
+        if (!hasSquidbOption(OPTIONS_DISABLE_DEFAULT_METHOD_HANDLING)) {
             normalPriorityPlugins.add(ModelMethodPlugin.class);
         }
-        if (!hasOption(OPTIONS_DISABLE_JAVADOC_COPYING)) {
+        if (!hasSquidbOption(OPTIONS_DISABLE_JAVADOC_COPYING)) {
             normalPriorityPlugins.add(JavadocPlugin.class);
         }
 
@@ -184,11 +184,11 @@ public class PluginEnvironment {
         normalPriorityPlugins.add(ViewModelSpecFieldPlugin.class);
         normalPriorityPlugins.add(InheritedModelSpecFieldPlugin.class);
 
-        if (!hasOption(OPTIONS_DISABLE_ENUM_PROPERTIES)) {
+        if (!hasSquidbOption(OPTIONS_DISABLE_ENUM_PROPERTIES)) {
             normalPriorityPlugins.add(EnumPluginBundle.class);
         }
 
-        if (!hasOption(OPTIONS_DISABLE_DEFAULT_CONSTANT_COPYING)) {
+        if (!hasSquidbOption(OPTIONS_DISABLE_DEFAULT_CONSTANT_COPYING)) {
             // This plugin claims any public static final fields not handled by the other plugins and copies them to
             // the generated model. Set to low priority so that by default user plugins can have first pass at
             // handing such fields.
@@ -306,7 +306,6 @@ public class PluginEnvironment {
      *
      * @param option the option to check
      * @return true if the option is set, false otherwise
-     * @deprecated use #removeOnGlobalLayoutListener instead
      */
     public boolean hasSquidbOption(String option) {
         return squidbOptions.contains(option);

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
@@ -321,7 +321,8 @@ public class PluginEnvironment {
      *
      * @return the map of annotation processing options
      *
-     * @see {@link #hasEnvOption(String)}
+     * @see #hasEnvOption(String)
+     * @see #getEnvOptionValue(String)
      */
     public Map<String, String> getEnvOptions() {
         return envOptions;
@@ -329,8 +330,8 @@ public class PluginEnvironment {
 
     /**
      * Returns whether the environment options obtained from {@link ProcessingEnvironment#getOptions()} contains the
-     * given key. This is a useful shortcut for plugins which declare their own options key but only need to check
-     * that the key is present, rather than checking the value for that key.
+     * given key. This is a convenience for plugins which declare their own options key but only need to check that the
+     * key is present, rather than checking the value for that key.
      * <p>
      * Note: Custom plugins should also be annotated with {@link SupportedOptions @SupportedOptions} to declare which
      * environment options keys they support; these will be reported to the toolchain accordingly.
@@ -339,6 +340,17 @@ public class PluginEnvironment {
      */
     public boolean hasEnvOption(String key) {
         return envOptions.containsKey(key);
+    }
+
+    /**
+     * Returns the value of the given option key from the environment options obtained from
+     * {@link ProcessingEnvironment#getOptions()}. Returns null if the key is not present or if the associated value
+     * is null. This is a convenience for plugins which declare their own options key.
+     *
+     * @return the value of the given environment option key
+     */
+    public String getEnvOptionValue(String key) {
+        return envOptions.get(key);
     }
 
     /**

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/PluginEnvironment.java
@@ -247,7 +247,7 @@ public class PluginEnvironment {
      * @param plugin the plugin class
      * @param priority the priority to give the plugin
      */
-    public void addPlugin(Class<? extends Plugin> plugin, PluginPriority priority) {
+    private void addPlugin(Class<? extends Plugin> plugin, PluginPriority priority) {
         switch (priority) {
             case LOW:
                 lowPriorityPlugins.add(plugin);

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/AndroidModelPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/AndroidModelPlugin.java
@@ -57,7 +57,7 @@ public class AndroidModelPlugin extends Plugin {
     public AndroidModelPlugin(ModelSpec<?> modelSpec, PluginEnvironment pluginEnv) {
         super(modelSpec, pluginEnv);
         modelSuperclass = modelSpec.accept(superclassVisitor, null);
-        generateConstructors = !pluginEnv.hasOption(PluginEnvironment.OPTIONS_DISABLE_DEFAULT_CONSTRUCTORS);
+        generateConstructors = !pluginEnv.hasSquidbOption(PluginEnvironment.OPTIONS_DISABLE_DEFAULT_CONSTRUCTORS);
     }
 
     @Override

--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/JavadocPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/JavadocPlugin.java
@@ -52,7 +52,7 @@ public class JavadocPlugin extends Plugin {
      */
     public static void writeJavadocFromElement(PluginEnvironment pluginEnv, JavaFileWriter writer, Element element)
             throws IOException {
-        if (!pluginEnv.hasOption(PluginEnvironment.OPTIONS_DISABLE_JAVADOC_COPYING)) {
+        if (!pluginEnv.hasSquidbOption(PluginEnvironment.OPTIONS_DISABLE_JAVADOC_COPYING)) {
             writer.writeJavadoc(pluginEnv.getUtils().getElements().getDocComment(element));
         }
     }

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/ModelFileWriter.java
@@ -168,7 +168,7 @@ public abstract class ModelFileWriter<T extends ModelSpec<?>> {
                         Expressions.callConstructor(modelSpec.getGeneratedClassName()), "newValuesStorage"),
                 Modifier.PROTECTED, Modifier.STATIC, Modifier.FINAL);
 
-        if (pluginEnv.hasOption(PluginEnvironment.OPTIONS_DISABLE_DEFAULT_VALUES)) {
+        if (pluginEnv.hasSquidbOption(PluginEnvironment.OPTIONS_DISABLE_DEFAULT_VALUES)) {
             writer.writeComment("--- property defaults disabled by plugin flag");
         } else {
             writer.beginInitializerBlock(true, true)
@@ -187,7 +187,7 @@ public abstract class ModelFileWriter<T extends ModelSpec<?>> {
     protected abstract void emitDefaultValuesInitializationBlock() throws IOException;
 
     protected void emitGettersAndSetters() throws IOException {
-        if (pluginEnv.hasOption(PluginEnvironment.OPTIONS_DISABLE_DEFAULT_GETTERS_AND_SETTERS)) {
+        if (pluginEnv.hasSquidbOption(PluginEnvironment.OPTIONS_DISABLE_DEFAULT_GETTERS_AND_SETTERS)) {
             writer.writeComment("--- getters and setters disabled by plugin flag");
         } else {
             writer.writeComment("--- getters and setters");

--- a/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/writers/TableModelFileWriter.java
@@ -166,7 +166,7 @@ public class TableModelFileWriter extends ModelFileWriter<TableModelSpecWrapper>
     @Override
     protected void emitGettersAndSetters() throws IOException {
         super.emitGettersAndSetters();
-        if (!pluginEnv.hasOption(PluginEnvironment.OPTIONS_DISABLE_DEFAULT_GETTERS_AND_SETTERS)) {
+        if (!pluginEnv.hasSquidbOption(PluginEnvironment.OPTIONS_DISABLE_DEFAULT_GETTERS_AND_SETTERS)) {
 
             MethodDeclarationParameters params = new MethodDeclarationParameters()
                     .setModifiers(Modifier.PUBLIC)


### PR DESCRIPTION
With this change, only options declared by SquiDB should be passed to APT in the list keyed by `squidbOptions`. Any others won't cause an error but a warning will be printed during builds.

Custom plugins should use their own option key(s) if they need to inspect APT options. This has always been the intended approach, but it was never clear; this change adds appropriate messaging to this effect.

Custom plugins should specify what option key(s) they support by using the `@SupportedOptions` annotation. This is not specifically required, but it does allow SquiDB to report those back to the toolchain so that the toolchain does not warn about seemingly unused options. Example:

```java
package com.fancy.plugins;

@SupportedOptions("fancyOptions")
public class FancyPlugin extends Plugin {
    /* ... */
}
```
```gradle
apt {
    arguments {
        squidbPlugins 'com.fancy.plugins.FancyPlugin:high'
        fancyOptions 'foo'
    }
}
```

Addresses #183. Replaces #198.