### PR TITLE
Apply enum hotfixes from PR #217

### DIFF
--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/EnumPropertyGenerator.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/generators/EnumPropertyGenerator.java
@@ -66,7 +66,7 @@ public class EnumPropertyGenerator extends BasicStringPropertyGenerator {
         final String argAsString = argName + "AsString";
         Expression condition = Expressions.fromString(argName + " == null");
         Expression ifTrue = Expressions.fromString("null");
-        Expression ifFalse = Expressions.callMethodOn(argName, "toString");
+        Expression ifFalse = Expressions.callMethodOn(argName, "name");
         writer.writeFieldDeclaration(CoreTypes.JAVA_STRING, argAsString,
                 new TernaryExpression(condition, ifTrue, ifFalse));
         writer.writeStatement(Expressions.callMethod("set", propertyName, argAsString));

--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -133,7 +133,7 @@ public class ModelTest extends DatabaseTestCase {
 
     public void testEnumProperties() {
         final TestEnum enumValue = TestEnum.APPLE;
-        final String enumAsString = TestEnum.APPLE.toString();
+        final String enumAsString = enumValue.name();
         TestModel model = new TestModel()
                 .setFirstName("A")
                 .setLastName("Z")

--- a/squidb-tests/src/com/yahoo/squidb/sql/PropertyTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/sql/PropertyTest.java
@@ -9,10 +9,12 @@ import com.yahoo.squidb.data.AbstractModel;
 import com.yahoo.squidb.data.SquidCursor;
 import com.yahoo.squidb.sql.Property.BooleanProperty;
 import com.yahoo.squidb.sql.Property.DoubleProperty;
+import com.yahoo.squidb.sql.Property.EnumProperty;
 import com.yahoo.squidb.sql.Property.IntegerProperty;
 import com.yahoo.squidb.sql.Property.LongProperty;
 import com.yahoo.squidb.sql.Property.StringProperty;
 import com.yahoo.squidb.test.DatabaseTestCase;
+import com.yahoo.squidb.test.TestEnum;
 import com.yahoo.squidb.test.TestModel;
 import com.yahoo.squidb.test.TestSubqueryModel;
 import com.yahoo.squidb.test.TestViewModel;
@@ -175,6 +177,9 @@ public class PropertyTest extends DatabaseTestCase {
 
         BooleanProperty falseLiteral = BooleanProperty.literal(false, "falseLit");
         assertEquals("SELECT 0 AS falseLit", Query.select(falseLiteral).toString());
+
+        EnumProperty enumLiteral = EnumProperty.literal(TestEnum.APPLE, "enumLit");
+        assertEquals("SELECT 'APPLE' AS enumLit", Query.select(enumLiteral).toString());
     }
 
 }

--- a/squidb-tests/src/com/yahoo/squidb/test/TestEnum.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/TestEnum.java
@@ -1,5 +1,10 @@
 package com.yahoo.squidb.test;
 
 public enum TestEnum {
-    APPLE, BANANA, CHERRY
+    APPLE, BANANA, CHERRY;
+
+    @Override
+    public String toString() {
+        return "I am a TestEnum with name " + name();
+    }
 }

--- a/squidb/src/com/yahoo/squidb/sql/Property.java
+++ b/squidb/src/com/yahoo/squidb/sql/Property.java
@@ -745,7 +745,8 @@ public abstract class Property<TYPE> extends Field<TYPE> implements Cloneable {
          * @param selectAs the alias to use. May be null.
          */
         public static <T extends Enum<T>> EnumProperty<T> literal(T literal, String selectAs) {
-            return new EnumProperty<>(null, String.valueOf(literal), selectAs, null);
+            return new EnumProperty<>(null, literal == null ? "null" : SqlUtils.sanitizeStringAsLiteral(literal.name()),
+                    selectAs, null);
         }
 
         @Override

--- a/squidb/src/com/yahoo/squidb/sql/SqlUtils.java
+++ b/squidb/src/com/yahoo/squidb/sql/SqlUtils.java
@@ -32,6 +32,9 @@ public class SqlUtils {
             } else if (arg instanceof AtomicBoolean) { // Not a subclass of Number so DatabaseUtils won't handle it
                 arg = ((AtomicBoolean) arg).get() ? 1 : 0;
                 resolved = true;
+            } else if (arg instanceof Enum<?>) {
+                arg = ((Enum<?>) arg).name();
+                resolved = true;
             } else if (arg instanceof ThreadLocal) {
                 arg = ((ThreadLocal<?>) arg).get();
             } else {


### PR DESCRIPTION
We should get these fixes for enums in ASAP and deal with the CompileContext changes in 217 separately. I confirmed that several test cases fail when I override toString in TestEnum, but pass again after the fixes were applied.