### PR TITLE
Fix copyDatabase method

### DIFF
--- a/squidb-ios-tests/src/com/yahoo/squidb/test/IOSSQLiteBindingProvider.java
+++ b/squidb-ios-tests/src/com/yahoo/squidb/test/IOSSQLiteBindingProvider.java
@@ -10,12 +10,19 @@ import com.yahoo.squidb.data.SquidDatabase;
 import com.yahoo.squidb.ios.IOSOpenHelper;
 
 public class IOSSQLiteBindingProvider extends SQLiteBindingProvider {
-    
-    public ISQLiteOpenHelper createOpenHelper(String databaseName, SquidDatabase.OpenHelperDelegate delegate, int version) {
+
+    public ISQLiteOpenHelper createOpenHelper(String databaseName, SquidDatabase.OpenHelperDelegate delegate,
+            int version) {
         return new IOSOpenHelper(getDatabasePath(), databaseName, delegate, version);
     }
-    
-    public static native String getDatabasePath() /*-[
+
+    public native String getWriteableTestDir() /*-[
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+        NSString * documentsDirectory = [paths objectAtIndex:0];
+        return [documentsDirectory stringByAppendingPathComponent:@"/TestDatabases"];
+    ]-*/;
+
+    private static native String getDatabasePath() /*-[
         NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);         
         NSString * documentsDirectory = [paths objectAtIndex:0];
         return [documentsDirectory stringByAppendingPathComponent:@"/Databases"];

--- a/squidb-tests/src/com/yahoo/squidb/android/SquidTestRunner.java
+++ b/squidb-tests/src/com/yahoo/squidb/android/SquidTestRunner.java
@@ -29,6 +29,11 @@ public class SquidTestRunner extends AndroidTestRunner {
                     int version) {
                 return selectedBinding.getOpenHelper(ContextProvider.getContext(), databaseName, delegate, version);
             }
+
+            @Override
+            public String getWriteableTestDir() {
+                return ContextProvider.getContext().getFilesDir().getPath();
+            }
         });
     }
 

--- a/squidb-tests/src/com/yahoo/squidb/android/TestReactiveDatabase.java
+++ b/squidb-tests/src/com/yahoo/squidb/android/TestReactiveDatabase.java
@@ -63,7 +63,7 @@ public class TestReactiveDatabase extends ReactiveSquidDatabase {
 
     @Override
     protected ISQLiteOpenHelper createOpenHelper(String databaseName, OpenHelperDelegate delegate, int version) {
-        return SQLiteBindingProvider.provideOpenHelper(databaseName, delegate, version);
+        return SQLiteBindingProvider.getInstance().createOpenHelper(databaseName, delegate, version);
     }
 
     @Override

--- a/squidb-tests/src/com/yahoo/squidb/test/SQLiteBindingProvider.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/SQLiteBindingProvider.java
@@ -16,12 +16,13 @@ public abstract class SQLiteBindingProvider {
         sProvider = provider;
     }
 
-    public static ISQLiteOpenHelper provideOpenHelper(String databaseName,
-            SquidDatabase.OpenHelperDelegate delegate, int version) {
-        return sProvider.createOpenHelper(databaseName, delegate, version);
+    public static SQLiteBindingProvider getInstance() {
+        return sProvider;
     }
 
     public abstract ISQLiteOpenHelper createOpenHelper(String databaseName,
             SquidDatabase.OpenHelperDelegate delegate, int version);
+
+    public abstract String getWriteableTestDir();
 
 }

--- a/squidb-tests/src/com/yahoo/squidb/test/TestDatabase.java
+++ b/squidb-tests/src/com/yahoo/squidb/test/TestDatabase.java
@@ -59,7 +59,7 @@ public class TestDatabase extends SquidDatabase {
 
     @Override
     protected ISQLiteOpenHelper createOpenHelper(String databaseName, OpenHelperDelegate delegate, int version) {
-        return SQLiteBindingProvider.provideOpenHelper(databaseName, delegate, version);
+        return SQLiteBindingProvider.getInstance().createOpenHelper(databaseName, delegate, version);
     }
 
     @Override

--- a/squidb/src/com/yahoo/squidb/utility/SquidUtilities.java
+++ b/squidb/src/com/yahoo/squidb/utility/SquidUtilities.java
@@ -193,17 +193,7 @@ public class SquidUtilities {
         byte[] buffer;
         int BUFFER_SIZE = 1024;
         buffer = new byte[BUFFER_SIZE];
-        while ((bytes = source.read(buffer)) != -1) {
-            if (bytes == 0) {
-                bytes = source.read();
-                if (bytes < 0) {
-                    break;
-                }
-                dest.write(bytes);
-                dest.flush();
-                continue;
-            }
-
+        while ((bytes = source.read(buffer)) > 0) {
             dest.write(buffer, 0, bytes);
         }
     }

--- a/squidb/src/com/yahoo/squidb/utility/SquidUtilities.java
+++ b/squidb/src/com/yahoo/squidb/utility/SquidUtilities.java
@@ -159,28 +159,22 @@ public class SquidUtilities {
 
     /**
      * Copy database files to the given folder. Useful for debugging.
+     * <p>
+     * This method is deprecated. Users should call {@link SquidDatabase#copyDatabase(File)} directly on their
+     * SquidDatabase instance instead.
      *
      * @param database the SquidDatabase to copy
      * @param toFolder the directory to copy files into
      */
+    @Deprecated
     public static void copyDatabase(SquidDatabase database, String toFolder) {
-        File folderFile = new File(toFolder);
-        if (!(folderFile.mkdirs() || folderFile.isDirectory())) {
-            Logger.e(Logger.LOG_TAG, "Error creating directories for database copy");
-            return;
-        }
-        File dbFile = new File(database.getDatabasePath());
-        try {
-            copyFile(dbFile, new File(folderFile.getAbsolutePath() + File.separator + database.getName()));
-        } catch (Exception e) {
-            Logger.e(Logger.LOG_TAG, "Error copying database " + database.getName(), e);
-        }
+        database.copyDatabase(new File(toFolder));
     }
 
     /**
      * Copy a file from one place to another
      */
-    private static void copyFile(File in, File out) throws Exception {
+    public static void copyFile(File in, File out) throws IOException {
         FileInputStream fis = new FileInputStream(in);
         FileOutputStream fos = new FileOutputStream(out);
         try {
@@ -211,7 +205,6 @@ public class SquidUtilities {
             }
 
             dest.write(buffer, 0, bytes);
-            dest.flush();
         }
     }
 }


### PR DESCRIPTION
SquidUtilities.copyDatabase never quite worked correctly. The two major problems were that 1) it never copied the supporting files like the journal or WAL file, meaning if the DB hadn't been checkpointed after a transaction the main file might not have the changes yet, and 2) to be really safe, the exclusive lock should be acquired while copying the file so that no other thread could do anything to the DB while it was being copied. This PR fixes these shortcomings by moving `copyDatabase` into SquidDatabase itself, deprecating the SquidUtilities version, and ensuring that the method is covered in our test suite.