### PR TITLE
Fix bug in containsNonNullValue

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -34,6 +34,23 @@ public class ModelTest extends DatabaseTestCase {
         assertFalse(model.isModified());
     }
 
+    public void testContainsNonNullValueMethod() {
+        TestModel model = new TestModel();
+        model.setFirstName("Test");
+        model.markSaved(); // Move values from set values into database values
+        assertEquals("Test", model.getFirstName());
+        assertFalse(model.fieldIsDirty(TestModel.FIRST_NAME));
+        assertNull(model.getSetValues());
+        assertTrue(model.containsNonNullValue(TestModel.FIRST_NAME));
+
+        model.setFirstName(null);
+        // Assert that despite the presence of a non-null value in the database values, containsNonNullValue
+        // defers to the "active" setValue.
+        assertNotNull(model.getDatabaseValues().get(TestModel.FIRST_NAME.getName()));
+        assertNull(model.getFirstName());
+        assertFalse(model.containsNonNullValue(TestModel.FIRST_NAME));
+    }
+
     public void testAddedModelMethods() {
         TestModel model = new TestModel();
 

--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -339,8 +339,12 @@ public abstract class AbstractModel implements Cloneable {
      * stored is not null
      */
     public boolean containsNonNullValue(Property<?> property) {
-        return (valuesContainsKey(setValues, property) && setValues.get(property.getName()) != null)
-                || (valuesContainsKey(values, property) && values.get(property.getName()) != null);
+        if (valuesContainsKey(setValues, property)) {
+            return setValues.get(property.getName()) != null;
+        } else if (valuesContainsKey(values, property)) {
+            return values.get(property.getName()) != null;
+        }
+        return false;
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -335,8 +335,9 @@ public abstract class AbstractModel implements Cloneable {
 
     /**
      * @param property the {@link Property} to check
-     * @return true if a value for this property has been read from the database or set by the user, and the value
-     * stored is not null
+     * @return true if a value for this property has been read from the database or set by the user, and the "active"
+     * value stored (i.e. the value that would be returned by a call to {@link #get(Property)}) is not null. Does not
+     * take into account column default values.
      */
     public boolean containsNonNullValue(Property<?> property) {
         if (valuesContainsKey(setValues, property)) {


### PR DESCRIPTION
Fixes a bug in our implementation of `containsNonNullValue()` that would return true in the case when a non-null value existed in the database values even if that value had been superseded by putting null in the setValues. Thanks to user @Aranda for pointing this out!