### PR TITLE
Fix clone()

### DIFF
--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -175,6 +175,17 @@ public class ModelTest extends DatabaseTestCase {
         model.clearAllTransitory();
         assertFalse(model.hasTransitory(key1));
         assertFalse(model.hasTransitory(key2));
+
+        // Test null transitory keys and values
+        model.putTransitory(key1, null);
+        assertTrue(model.hasTransitory(key1));
+        assertTrue(model.checkAndClearTransitory(key1));
+        assertFalse(model.hasTransitory(key1));
+
+        model.putTransitory(null, "A");
+        assertTrue(model.hasTransitory(null));
+        assertTrue(model.checkAndClearTransitory(null));
+        assertFalse(model.hasTransitory(null));
     }
 
     public void testEnumProperties() {

--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -62,13 +62,28 @@ public class ModelTest extends DatabaseTestCase {
     }
 
     public void testClone() {
+        // Init model with set values, regular values, and transitory values
         TestModel model = new TestModel();
         model.setFirstName("Sam");
+        model.markSaved();
+        model.setLastName("B");
+        model.putTransitory("a", "A");
         TestModel clone = model.clone();
+        clone.putTransitory("b", "B");
 
         assertTrue(model != clone);
+        assertTrue(model.getSetValues() != clone.getSetValues());
+        assertTrue(model.getDatabaseValues() != clone.getDefaultValues());
+
         assertEquals(clone, model);
+        assertEquals(model.getSetValues(), clone.getSetValues());
+        assertEquals(model.getDatabaseValues(), clone.getDatabaseValues());
+
         assertEquals("Sam", clone.getFirstName());
+        assertEquals("B", clone.getLastName());
+        assertEquals("A", clone.getTransitory("a"));
+        assertEquals("B", clone.getTransitory("b"));
+        assertFalse(model.hasTransitory("b"));
     }
 
     public void testCrudMethods() {

--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -161,6 +161,12 @@ public class ModelTest extends DatabaseTestCase {
         assertFalse(model.hasTransitory(key1));
         assertTrue(model.checkAndClearTransitory(key2));
         assertFalse(model.hasTransitory(key2));
+
+        model.putTransitory(key1, "A");
+        model.putTransitory(key2, "B");
+        model.clearAllTransitory();
+        assertFalse(model.hasTransitory(key1));
+        assertFalse(model.hasTransitory(key2));
     }
 
     public void testEnumProperties() {

--- a/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
+++ b/squidb-tests/src/com/yahoo/squidb/data/ModelTest.java
@@ -84,6 +84,14 @@ public class ModelTest extends DatabaseTestCase {
         assertEquals("A", clone.getTransitory("a"));
         assertEquals("B", clone.getTransitory("b"));
         assertFalse(model.hasTransitory("b"));
+
+        // Test cloning an empty model
+        TestModel empty = new TestModel();
+        TestModel emptyClone = empty.clone();
+
+        assertNull(emptyClone.getSetValues());
+        assertNull(emptyClone.getDatabaseValues());
+        assertNull(emptyClone.getAllTransitoryKeys());
     }
 
     public void testCrudMethods() {

--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -59,6 +59,13 @@ import java.util.Set;
  * model.readPropertiesFromCursor(cursor);
  * </pre>
  *
+ * <p>
+ * <h3>Cloning a model</h3>
+ * All models can be {@link #clone() cloned}, which will create a new model instance containing the same values and set
+ * values. Transitory values will be copied to a new transitory storage for the new model but will not be a deep copy
+ * of the values themselves. If you require a deep copy of stored transitory values, you should implement custom
+ * cloning logic.
+ *
  * @see com.yahoo.squidb.data.TableModel
  * @see com.yahoo.squidb.data.ViewModel
  */
@@ -184,6 +191,10 @@ public abstract class AbstractModel implements Cloneable {
         if (values != null) {
             clone.values = newValuesStorage();
             clone.values.putAll(values);
+        }
+
+        if (transitoryData != null) {
+            clone.transitoryData = new HashMap<>(transitoryData);
         }
         return clone;
     }
@@ -489,6 +500,17 @@ public abstract class AbstractModel implements Cloneable {
             return null;
         }
         return transitoryData.remove(key);
+    }
+
+    /**
+     * Clears all transitory key/value pairs
+     *
+     * @see #clearTransitory(String)
+     */
+    public void clearAllTransitory() {
+        if (transitoryData != null) {
+            transitoryData.clear();
+        }
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -508,9 +508,7 @@ public abstract class AbstractModel implements Cloneable {
      * @see #clearTransitory(String)
      */
     public void clearAllTransitory() {
-        if (transitoryData != null) {
-            transitoryData.clear();
-        }
+        transitoryData = null;
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -534,7 +534,7 @@ public abstract class AbstractModel implements Cloneable {
      * @return true if a transitory object is set for the given key, false otherwise
      */
     public boolean hasTransitory(String key) {
-        return getTransitory(key) != null;
+        return transitoryData != null && transitoryData.containsKey(key);
     }
 
     /**
@@ -544,7 +544,11 @@ public abstract class AbstractModel implements Cloneable {
      * @return true if a transitory object is set for the given flag, false otherwise
      */
     public boolean checkAndClearTransitory(String key) {
-        return clearTransitory(key) != null;
+        if (hasTransitory(key)) {
+            clearTransitory(key);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/squidb/src/com/yahoo/squidb/data/AbstractModel.java
+++ b/squidb/src/com/yahoo/squidb/data/AbstractModel.java
@@ -79,7 +79,10 @@ public abstract class AbstractModel implements Cloneable {
 
     // --- abstract methods
 
-    /** Get the default values for this object */
+    /**
+     * @return the default values for this object. These values may be shared between model instances and should not
+     * be modified
+     */
     public abstract ValuesStorage getDefaultValues();
 
     // --- data store variables and management
@@ -93,17 +96,17 @@ public abstract class AbstractModel implements Cloneable {
     /** Transitory Metadata (not saved in database) */
     protected HashMap<String, Object> transitoryData = null;
 
-    /** Get the database-read values for this object */
+    /** @return the database-read values for this object */
     public ValuesStorage getDatabaseValues() {
         return values;
     }
 
-    /** Get the user-set values for this object */
+    /** @return the user-set values for this object */
     public ValuesStorage getSetValues() {
         return setValues;
     }
 
-    /** Get a list of all field/value pairs merged across data sources */
+    /** @return a mapping of all field/value pairs merged across data sources */
     public ValuesStorage getMergedValues() {
         ValuesStorage mergedValues = newValuesStorage();
 


### PR DESCRIPTION
Fixes bad handling of transitory values in `AbstractModel.clone()`

Closes #251 