### PR TITLE
Create Table/View SQL [4.0]

### DIFF
--- a/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/TableModelSpecFieldPlugin.java
+++ b/squidb-processor/src/com/yahoo/squidb/processor/plugins/defaults/properties/TableModelSpecFieldPlugin.java
@@ -184,11 +184,8 @@ public class TableModelSpecFieldPlugin extends BaseFieldPlugin<TableModelSpecWra
 
     @Override
     public void afterDeclareSchema(TypeSpec.Builder builder) {
-        for (PropertyGenerator generator : modelSpec.getPropertyGenerators()) {
-            if (generator instanceof RowidPropertyGenerator) {
-                writeRowidSupportMethods(builder, generator.getPropertyName());
-            }
-        }
+        RowidPropertyGenerator rowidPropertyGenerator = modelSpec.getMetadata(METADATA_KEY_ROWID_ALIAS_PROPERTY_GENERATOR);
+        writeRowidSupportMethods(builder, rowidPropertyGenerator.getPropertyName());
     }
 
     private void writeRowidSupportMethods(TypeSpec.Builder builder, String propertyName) {

--- a/squidb/src/com/yahoo/squidb/sql/ColumnDefinitionVisitor.java
+++ b/squidb/src/com/yahoo/squidb/sql/ColumnDefinitionVisitor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the Apache 2.0 License.
+ * See the accompanying LICENSE file for terms.
+ */
+package com.yahoo.squidb.sql;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Implementation of {@link com.yahoo.squidb.sql.Property.PropertyVisitor}that builds column definitions for
+ * {@link Property}s
+ */
+public class ColumnDefinitionVisitor implements Property.PropertyVisitor<Void, StringBuilder> {
+    @Nullable
+    private Void appendColumnDefinition(@Nonnull String type, @Nonnull Property<?> property,
+            @Nonnull StringBuilder sql) {
+        sql.append(property.getName()).append(" ").append(type);
+        if (!SqlUtils.isEmpty(property.getColumnDefinition())) {
+            sql.append(" ").append(property.getColumnDefinition());
+        }
+        return null;
+    }
+
+    @Override
+    @Nullable
+    public Void visitDouble(@Nonnull Property<Double> property, @Nonnull StringBuilder sql) {
+        return appendColumnDefinition("REAL", property, sql);
+    }
+
+    @Override
+    @Nullable
+    public Void visitInteger(@Nonnull Property<Integer> property, @Nonnull StringBuilder sql) {
+        return appendColumnDefinition("INTEGER", property, sql);
+    }
+
+    @Override
+    @Nullable
+    public Void visitLong(@Nonnull Property<Long> property, @Nonnull StringBuilder sql) {
+        return appendColumnDefinition("INTEGER", property, sql);
+    }
+
+    @Override
+    @Nullable
+    public Void visitString(@Nonnull Property<String> property, @Nonnull StringBuilder sql) {
+        return appendColumnDefinition("TEXT", property, sql);
+    }
+
+    @Override
+    @Nullable
+    public Void visitBoolean(@Nonnull Property<Boolean> property, @Nonnull StringBuilder sql) {
+        return appendColumnDefinition("INTEGER", property, sql);
+    }
+
+    @Override
+    @Nullable
+    public Void visitBlob(@Nonnull Property<byte[]> property, @Nonnull StringBuilder sql) {
+        return appendColumnDefinition("BLOB", property, sql);
+    }
+}

--- a/squidb/src/com/yahoo/squidb/sql/SqlBuilder.java
+++ b/squidb/src/com/yahoo/squidb/sql/SqlBuilder.java
@@ -14,10 +14,8 @@ import javax.annotation.Nullable;
 
 public final class SqlBuilder {
 
-    private static final int STRING_BUILDER_INITIAL_CAPACITY = 128;
-
     @Nonnull
-    public final StringBuilder sql = new StringBuilder(STRING_BUILDER_INITIAL_CAPACITY);
+    public final StringBuilder sql = new StringBuilder(SqlStatement.STRING_BUILDER_INITIAL_CAPACITY);
     @Nonnull
     public final CompileContext compileContext;
 

--- a/squidb/src/com/yahoo/squidb/sql/SqlStatement.java
+++ b/squidb/src/com/yahoo/squidb/sql/SqlStatement.java
@@ -14,6 +14,9 @@ public interface SqlStatement {
 
     Object[] EMPTY_ARGS = new Object[0];
 
+    /** Suggested initial capacity for StringBuilders when compiling SQL statements */
+    int STRING_BUILDER_INITIAL_CAPACITY = 256;
+
     /** Character substituted by values when used in SQL statements */
     String REPLACEABLE_PARAMETER = "?";
     String REPLACEABLE_ARRAY_PARAMETER = "[?]";

--- a/squidb/src/com/yahoo/squidb/sql/Table.java
+++ b/squidb/src/com/yahoo/squidb/sql/Table.java
@@ -7,7 +7,6 @@ package com.yahoo.squidb.sql;
 
 import com.yahoo.squidb.data.TableModel;
 import com.yahoo.squidb.sql.Property.LongProperty;
-import com.yahoo.squidb.sql.Property.PropertyVisitor;
 
 import java.util.List;
 
@@ -105,12 +104,13 @@ public class Table extends SqlTable<TableModel> {
         return super.toString() + " ModelClass=" + modelClass.getSimpleName() + " TableConstraint=" + tableConstraint;
     }
 
+    private static final ColumnDefinitionVisitor columnDefVisitor = new ColumnDefinitionVisitor();
+
     /**
      * Append a CREATE TABLE statement that would create this table and its columns. Users should not call
      * this method and instead let {@link com.yahoo.squidb.data.SquidDatabase} build tables automatically.
      */
-    public void appendCreateTableSql(@Nonnull CompileContext compileContext, @Nonnull StringBuilder sql,
-            @Nonnull PropertyVisitor<Void, StringBuilder> propertyVisitor) {
+    public void appendCreateTableSql(@Nonnull CompileContext compileContext, @Nonnull StringBuilder sql) {
         sql.append("CREATE TABLE IF NOT EXISTS ").append(getExpression()).append('(');
         boolean needsComma = false;
         for (Property<?> property : properties) {
@@ -120,13 +120,25 @@ public class Table extends SqlTable<TableModel> {
             if (needsComma) {
                 sql.append(", ");
             }
-            property.accept(propertyVisitor, sql);
+            property.accept(columnDefVisitor, sql);
             needsComma = true;
         }
         if (!SqlUtils.isEmpty(getTableConstraint())) {
             sql.append(", ").append(getTableConstraint());
         }
         sql.append(')');
+    }
+
+    /**
+     * @return the <code>CREATE TABLE</code> statement for creating this table. Users should generally not need to call
+     * this method directly unless they are not working with a SquidDatabase instance and wish to create tables
+     * manually.
+     */
+    @Nonnull
+    public String getCreateTableSql() {
+        StringBuilder sql = new StringBuilder(SqlStatement.STRING_BUILDER_INITIAL_CAPACITY);
+        appendCreateTableSql(CompileContext.defaultContextForVersionCode(VERSION_FOR_TO_STRING), sql);
+        return sql.toString();
     }
 
     /**
@@ -148,7 +160,7 @@ public class Table extends SqlTable<TableModel> {
     @Nonnull
     public LongProperty getRowIdProperty() {
         if (rowidProperty == null) {
-            throw new UnsupportedOperationException("Table " + getExpression() + " has no id property defined");
+            throw new UnsupportedOperationException("Table " + getExpression() + " has no rowid property defined");
         }
         return rowidProperty;
     }

--- a/squidb/src/com/yahoo/squidb/sql/Table.java
+++ b/squidb/src/com/yahoo/squidb/sql/Table.java
@@ -7,6 +7,7 @@ package com.yahoo.squidb.sql;
 
 import com.yahoo.squidb.data.TableModel;
 import com.yahoo.squidb.sql.Property.LongProperty;
+import com.yahoo.squidb.utility.VersionCode;
 
 import java.util.List;
 
@@ -130,14 +131,19 @@ public class Table extends SqlTable<TableModel> {
     }
 
     /**
+     * @param compileContext a {@link CompileContext} for generating the <code>CREATE TABLE</code> statement. This
+     * should be a context holding the version code of the SQLite build being targeted by the user. A default context
+     * for a given SQLite version can be constructed using
+     * {@link CompileContext#defaultContextForVersionCode(VersionCode)}, or a context can be built manually using
+     * {@link com.yahoo.squidb.sql.CompileContext.Builder}
      * @return the <code>CREATE TABLE</code> statement for creating this table. Users should generally not need to call
      * this method directly unless they are not working with a SquidDatabase instance and wish to create tables
      * manually.
      */
     @Nonnull
-    public String getCreateTableSql() {
+    public String getCreateTableSql(@Nonnull CompileContext compileContext) {
         StringBuilder sql = new StringBuilder(SqlStatement.STRING_BUILDER_INITIAL_CAPACITY);
-        appendCreateTableSql(CompileContext.defaultContextForVersionCode(VERSION_FOR_TO_STRING), sql);
+        appendCreateTableSql(compileContext, sql);
         return sql.toString();
     }
 

--- a/squidb/src/com/yahoo/squidb/sql/View.java
+++ b/squidb/src/com/yahoo/squidb/sql/View.java
@@ -6,6 +6,7 @@
 package com.yahoo.squidb.sql;
 
 import com.yahoo.squidb.data.ViewModel;
+import com.yahoo.squidb.utility.VersionCode;
 
 import java.util.Collections;
 import java.util.List;
@@ -112,14 +113,19 @@ public class View extends QueryTable {
     }
 
     /**
+     * @param compileContext a {@link CompileContext} for generating the <code>CREATE VIEW</code> statement. This
+     * should be a context holding the version code of the SQLite build being targeted by the user. A default context
+     * for a given SQLite version can be constructed using
+     * {@link CompileContext#defaultContextForVersionCode(VersionCode)}, or a context can be built manually using
+     * {@link com.yahoo.squidb.sql.CompileContext.Builder}
      * @return the <code>CREATE VIEW</code> statement for creating this view. Users should generally not need to call
      * this method directly unless they are not working with a SquidDatabase instance and wish to create views
      * manually.
      */
     @Nonnull
-    public String getCreateViewSql() {
+    public String getCreateViewSql(@Nonnull CompileContext compileContext) {
         StringBuilder sql = new StringBuilder(SqlStatement.STRING_BUILDER_INITIAL_CAPACITY);
-        appendCreateViewSql(CompileContext.defaultContextForVersionCode(VERSION_FOR_TO_STRING), sql);
+        appendCreateViewSql(compileContext, sql);
         return sql.toString();
     }
 }

--- a/squidb/src/com/yahoo/squidb/sql/View.java
+++ b/squidb/src/com/yahoo/squidb/sql/View.java
@@ -101,7 +101,7 @@ public class View extends QueryTable {
      * Append the SQL statement that creates this View to the given {@link StringBuilder}. Users should not call
      * this method and instead let {@link com.yahoo.squidb.data.SquidDatabase} build views automatically.
      */
-    public void createViewSql(@Nonnull CompileContext compileContext, @Nonnull StringBuilder sql) {
+    public void appendCreateViewSql(@Nonnull CompileContext compileContext, @Nonnull StringBuilder sql) {
         sql.append("CREATE ");
         if (temporary) {
             sql.append("TEMPORARY ");
@@ -109,5 +109,17 @@ public class View extends QueryTable {
         sql.append("VIEW IF NOT EXISTS ")
                 .append(getExpression()).append(" AS ")
                 .append(query.toRawSql(compileContext));
+    }
+
+    /**
+     * @return the <code>CREATE VIEW</code> statement for creating this view. Users should generally not need to call
+     * this method directly unless they are not working with a SquidDatabase instance and wish to create views
+     * manually.
+     */
+    @Nonnull
+    public String getCreateViewSql() {
+        StringBuilder sql = new StringBuilder(SqlStatement.STRING_BUILDER_INITIAL_CAPACITY);
+        appendCreateViewSql(CompileContext.defaultContextForVersionCode(VERSION_FOR_TO_STRING), sql);
+        return sql.toString();
     }
 }

--- a/squidb/src/com/yahoo/squidb/sql/VirtualTable.java
+++ b/squidb/src/com/yahoo/squidb/sql/VirtualTable.java
@@ -6,7 +6,6 @@
 package com.yahoo.squidb.sql;
 
 import com.yahoo.squidb.data.TableModel;
-import com.yahoo.squidb.sql.Property.PropertyVisitor;
 import com.yahoo.squidb.utility.VersionCode;
 
 import java.util.List;
@@ -88,8 +87,7 @@ public class VirtualTable extends Table {
      * call this method and instead let {@link com.yahoo.squidb.data.SquidDatabase} build tables automatically.
      */
     @Override
-    public void appendCreateTableSql(@Nonnull CompileContext compileContext, @Nonnull StringBuilder sql,
-            @Nonnull PropertyVisitor<Void, StringBuilder> propertyVisitor) {
+    public void appendCreateTableSql(@Nonnull CompileContext compileContext, @Nonnull StringBuilder sql) {
         sql.append("CREATE VIRTUAL TABLE ");
         if (compileContext.getVersionCode().isAtLeast(SQLITE_VERSION_IF_NOT_EXISTS)) {
             sql.append("IF NOT EXISTS ");


### PR DESCRIPTION
Add getCreateTableSql and getCreateViewSql methods to Table and View. This makes it easier for users to use our code generation/model objects for defining schemas and building SQL statements more easily without committing to using SquidDatabase as the DAO. 