### PR TITLE
Added toString to ValuesStorage to ease debugging in Mockito tests.

### DIFF
--- a/squidb/src/com/yahoo/squidb/data/ValuesStorage.java
+++ b/squidb/src/com/yahoo/squidb/data/ValuesStorage.java
@@ -179,6 +179,18 @@ public abstract class ValuesStorage {
     }
 
     @Override
+    public String toString() {
+        StringBuilder result = new StringBuilder();
+        for (String key : keySet()) {
+            result.append(key);
+            result.append(": \"");
+            result.append(get(key));
+            result.append("\"\n");
+        }
+        return result.toString();
+    }
+
+    @Override
     public abstract boolean equals(@Nullable Object o);
 
     @Override

--- a/squidb/src/com/yahoo/squidb/data/ValuesStorage.java
+++ b/squidb/src/com/yahoo/squidb/data/ValuesStorage.java
@@ -180,13 +180,15 @@ public abstract class ValuesStorage {
 
     @Override
     public String toString() {
-        StringBuilder result = new StringBuilder();
-        for (String key : keySet()) {
-            result.append(key);
+        StringBuilder result = new StringBuilder(getClass().getSimpleName());
+        result.append(": {\n");
+        for (Map.Entry<String, Object> entry : valueSet()) {
+            result.append(entry.getKey());
             result.append(": \"");
-            result.append(get(key));
+            result.append(entry.getValue());
             result.append("\"\n");
         }
+        result.append("}\n");
         return result.toString();
     }
 


### PR DESCRIPTION
When testing with mockito and expecting an entity generated from a tablespec one currently gets the following error from mockito (and most likely other expecting frameworks, too) if an argument does not match the expected values:

Actual invocation has different arguments:
myDao.save(
    MyFromSpecEntity
set values:
com.yahoo.squidb.android.ContentValuesStorage@43ccf00c
values:
null

);

This is not a real problem when running in the IDE but causes extra effort when getting such an error in a CI test. I therefore simply added a toString that outputs all fields from the ValueStorage to ease debugging.
